### PR TITLE
Add windshaft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ typings/
 
 # next.js build output
 .next
+
+.directory

--- a/breakable_toy/.directory
+++ b/breakable_toy/.directory
@@ -1,0 +1,6 @@
+[Dolphin]
+Timestamp=2018,6,5,14,57,7
+Version=4
+
+[Settings]
+HiddenFilesShown=true

--- a/breakable_toy/.directory
+++ b/breakable_toy/.directory
@@ -1,6 +1,0 @@
-[Dolphin]
-Timestamp=2018,6,5,14,57,7
-Version=4
-
-[Settings]
-HiddenFilesShown=true

--- a/breakable_toy/docker-compose.yml
+++ b/breakable_toy/docker-compose.yml
@@ -1,6 +1,25 @@
-version: '2.1'
+version: '3.1'
 services:
+  windshaft:
+    image: quay.io/azavea/windshaft:latest
+    depends_on:
+      - redis
+      - database
+    # run server entrypoint script on startup
+    command: "server/server.js"
+    volumes:
+      # map this directory's server folder to
+      # /opt/windshaft/server on the container
+      - ./windshaft:/opt/windshaft/server
+    ports:
+      # serve port 5000 on the container as port 5000 on the machine
+      - "5000:5000"
   database:
     image: quay.io/azavea/postgis:2.3-postgres9.6-slim
     expose:
+      # expose port 5432 to other containers in docker-compose
       - "5432"
+  redis:
+    image: redis:3.2
+    expose:
+    - "6379"

--- a/breakable_toy/docker-compose.yml
+++ b/breakable_toy/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: quay.io/azavea/windshaft:latest
     depends_on:
       - redis
-      - database
+      - db
     # run server entrypoint script on startup
     command: "server/server.js"
     volumes:
@@ -14,7 +14,7 @@ services:
     ports:
       # serve port 5000 on the container as port 5000 on the machine
       - "5000:5000"
-  database:
+  db:
     image: quay.io/azavea/postgis:2.3-postgres9.6-slim
     expose:
       # expose port 5432 to other containers in docker-compose

--- a/breakable_toy/scripts/console
+++ b/breakable_toy/scripts/console
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -eu
+
+
+function usage() {
+    echo -n \
+"Usage: $(basename $0) SERVICE
+
+Create interactive console for any of the services in the project.
+
+COMMAND can be any service name as specified in docker-compose.yml.
+"
+}
+
+
+function main() {
+
+    if [ "${1}" = "windshaft" ]
+    then
+        docker-compose exec windshaft bash
+    elif [ "${1}" = "db" ]
+    then
+        docker-compose exec -u postgres db psql -d postgres
+    else
+        docker-compose exec ${1} bash
+    fi
+}
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        SERVER_COMMAND=${1:-start}
+        main $SERVER_COMMAND
+    fi
+    exit
+fi

--- a/breakable_toy/scripts/load_db.sh
+++ b/breakable_toy/scripts/load_db.sh
@@ -7,7 +7,7 @@ POSTGRES_PASSWORD="${POSTGRES_DB:-mysecretpassword}"
 POSTGRES_DB="${POSTGRES_DB:-$POSTGRES_USER}"
 
 # Execute psql commands on the database container for performance reasons.
-PSQL="docker exec -i $(docker-compose ps -q database) gosu ${POSTGRES_USER} psql -d ${POSTGRES_DB}"
+PSQL="docker exec -i $(docker-compose ps -q db) gosu ${POSTGRES_USER} psql -d ${POSTGRES_DB}"
 # echo "psql command: ${PSQL}"
 
 function usage() {

--- a/breakable_toy/scripts/setup
+++ b/breakable_toy/scripts/setup
@@ -18,7 +18,7 @@ then
         docker-compose -f docker-compose.yml build
 
         # Launch database container so we can populate it.
-        docker-compose up -d database
+        docker-compose up -d db
 
         # Load data fixtures.
         ./scripts/load_db.sh

--- a/breakable_toy/windshaft/server.js
+++ b/breakable_toy/windshaft/server.js
@@ -1,0 +1,72 @@
+/**
+ * Entrypoint for Windshaft server
+ * Copy-paste of example from Azavea Windshaft repo
+ */
+
+var Windshaft = require('windshaft');
+
+// Configure pluggable URLs
+// =========================
+// The config object must define grainstore config (generally just
+// postgres connection details), redis config, a base url and a function
+// that adds 'dbname' and 'table' variables onto the Express.js req.params
+// object.  In this example, the base URL is such that dbname and table will
+// automatically be added to the req.params object by express.js. req2params
+// can be extended to allow full control over the specifying of dbname and
+// table, and also allows for the req.params object to be extended with
+// other variables, such as:
+//
+// * sql - custom sql query to narrow results shown in map)
+// * geom_type - specify the geom type (point|polygon) to get more
+//               appropriate default styles
+// * cache_buster - forces the creation of a new render object, nullifying
+//                  existing metatile caches
+// * interactivity - specify the column to use in the UTFGrid
+//                   interactivity layer (defaults to null)
+// * style - specify map style in the Carto map language on a per tile basis
+//
+// the base url is also used for persisiting and retrieving map styles via:
+//
+// GET  base_url + '/style' (returns a map style)
+// POST base_url + '/style' (allows specifying of a style in Carto markup
+//                           in the 'style' form variable).
+//
+// beforeTileRender and afterTileRender could be defined if you want yo
+// implement your own tile cache policy. See an example below
+
+var config = {
+        base_url: '/database/:dbname/table/:table',
+        base_url_mapconfig: '/database/:dbname/layergroup',
+        req2params: function(req, callback){
+          callback(null,req)
+        },
+        grainstore: {
+          datasource: {
+            user:'postgres', host: 'db',
+        		port: 5432
+          }
+        }, //see grainstore npm for other options
+        renderCache: {
+          ttl: 60000, // seconds
+        },
+        mapnik: {
+          metatile: 4,
+          bufferSize:64
+        },
+        redis: {host: 'redis', port: 6379},
+        // this two filters are optional
+        beforeTileRender: function(req, res, callback) {
+            callback(null);
+        },
+        afterTileRender: function(req, res, tile, headers, callback) {
+            callback(null, tile, headers);
+        }
+    };
+
+// Initialize tile server on port 4000
+var ws = new Windshaft.Server(config);
+ws.listen(5000);
+console.log("map tiles are now being served out of: http://localhost:5000"
+            + config.base_url + '/:z/:x/:y.*');
+
+// Specify .png, .png8 or .grid.json tiles.


### PR DESCRIPTION
## Overview

This PR adds Windshaft to the project, which draws from the pre-existing database to serve tiles from a template URL.

## Notes

Strictly speaking, this PR won't allow Windshaft to serve tiles properly as the example data set is not properly formatted, and altering the data seems outside the scope of this branch. In order to properly format the data, run './scripts/console db' to enter the database console and create a new column in the 'pa_gardens' table called 'the_geom_webmercator' that contains the values of the pre-existing 'geom' column re-projected to have a SRID of 3857. 
~~~~

ALTER TABLE pa_gardens ADD COLUMN the_geom_webmercator geometry(POINT, 3857);
UPDATE pa_gardens SET the_geom_webmercator = ST_Transform(ST_SetSRID(geom, 4326), 3857);

~~~~


## Testing Instructions

 * Run ./server/setup to build containers. All containers are built from images, but this is necessary in order to load in data to PostGIS.
 * Run ./scripts/server to start the containers (db, redis, and windshaft). Windshaft should tell you that map tiles are now being served.
 * Visit localhost:5000 and you should receive a default CartoDB Maps API message. Enter test values in the format http://localhost:5000/database/postgres/table/pa_gardens/{z}/{x}/{y}.png. The server should then complain that the column "the_geom_webmercator" does not exist; see Notes section for details on this.

Resolves #1

