### PR TITLE
Re-organize tiler dockerfile to benefit from layer caching

### DIFF
--- a/node_lambnik/src/tiler/Dockerfile
+++ b/node_lambnik/src/tiler/Dockerfile
@@ -1,11 +1,15 @@
 FROM node:8.10-slim
 
-COPY . /home/tiler
+# Copy files needed for installing packages first
+COPY package.json yarn.lock /home/tiler/
 WORKDIR /home/tiler
 
 # install and update yarn
 RUN npm install -g yarn
 RUN yarn --version
 RUN yarn install
+
+# Copy remaining files after package installation to benefit from layer caching
+COPY . /home/tiler
 
 CMD ["yarn", "dev"]


### PR DESCRIPTION
## Overview

Re-ordered statements in the tiler's dockerfile in order to benefit from layer caching, so that node modules only need to be re-installed when packages change.

## Testing Instructions

 * Run the project as per normal (`./scripts/update` followed by `./scripts/server`). Updating non-package source files should no longer cause `yarn install` to run every time.

