### PR TITLE
Feature/utf grid support

### DIFF
--- a/node_lambnik/src/demo/pwd_inlets_index.html
+++ b/node_lambnik/src/demo/pwd_inlets_index.html
@@ -1,67 +1,73 @@
 <!DOCTYPE html>
 <html>
+
 <head>
+    <meta charset="utf-8">
+    <title>PWD Inlets</title>
+
     <link href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css" rel="stylesheet" type="text/css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet-src.js"></script>
     <script src="https://danzel.github.io/Leaflet.utfgrid/src/leaflet.utfgrid.js"></script>
-    <meta charset="utf-8">
-    <title>PWD Inlets</title>
-    <style>
-        #map {
-            width:100%;
-            height:500px;
-        }
-    </style>
 </head>
+
 <body>
-<select id="inlet-type">
-    <option value='all'>All</option>
-    <option value='a'>A</option>
-    <option value='b'>B</option>
-    <option value='c'>C</option>
-    <option value='d'>D</option>
-</select>
-<div id='map'></div>
+<div class="container">
+    <h3>PWD Inlets</h3>
+    <div id="map" style="width: 705px; height: 375px"></div>
+</div>
+<style>
+    #map {
+        border: 1px solid rgba(0, 0, 0, 0);
+        border-radius: 6px;
+        display: inline-block;
+    }
 
-
+    .container {
+        width: 100%;
+        margin-top: 30px;
+        align-content: center;
+        text-align: center;
+    }
+</style>
 <script>
+    "use-strict"
 
-    //var LAMBNIK_DOMAIN = 'https://d1y4se194ujvw1.cloudfront.net';
-    // If you're running locally and want to test, use this host instead
-    var LAMBNIK_DOMAIN = 'http://localhost:9001';
+    document.addEventListener('DOMContentLoaded', function onload() {
+        // create map object
+        var map = L.map('map', {
+            center: [39.96, -75.15], zoom: 13
+        });
 
-    var center = new L.LatLng(39.95, -75.15),
-        map = new L.Map('map', {center: center, zoom: 13}),
-        baselayer = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png').addTo(map),
-        tileLayer = L.tileLayer(LAMBNIK_DOMAIN + '/tile/{z}/{x}/{y}?type={type}', {
-            type: function() {
-                return document.getElementById('inlet-type').value;
-            }}).addTo(map);
+        // add basemap
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        }).addTo(map);
 
-    var grid = new L.UtfGrid(LAMBNIK_DOMAIN + '/grid/{z}/{x}/{y}?type={type}', {
-        useJsonP: false,
-        type: function() {
-            return document.getElementById('inlet-type').value;
-        }
+
+        // add tileserver
+        // un-comment out the path that you want to test
+        // var TILESERVER_PATH = 'https://d28f32z0lbuk2f.cloudfront.net/';
+        var TILESERVER_PATH = 'http://localhost:9001/';
+
+        // add custom tile layer
+        L.tileLayer(TILESERVER_PATH + '/tile/{z}/{x}/{y}.png').addTo(map);
+
+        // add utf grid
+        var grid = new L.UtfGrid(TILESERVER_PATH + "/grid/{z}/{x}/{y}", {
+            useJsonP: false
+        });
+
+        map.addLayer(grid);
+        grid.on('click', function(e) {
+            if (e.data) {
+                alert("This inlet if of type: " + e.data.inlettype);
+                console.log(JSON.stringify(e.data))
+            }
+        });
     });
 
-    map.addLayer(grid);
-
-    grid.on('click', function(e) {
-        if (e.data) {
-            alert(e.data.inlettype);
-        }
-    });
-
-    document.addEventListener('DOMContentLoaded',function() {
-
-        document.getElementById('inlet-type').onchange = function(e) {
-            map.removeLayer(tileLayer);
-            map.removeLayer(grid);
-            map.addLayer(tileLayer);
-            map.addLayer(grid);
-        };
-    });
 </script>
 </body>
+
 </html>

--- a/node_lambnik/src/demo/pwd_inlets_index.html
+++ b/node_lambnik/src/demo/pwd_inlets_index.html
@@ -1,61 +1,67 @@
 <!DOCTYPE html>
 <html>
-
 <head>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css" rel="stylesheet" type="text/css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet-src.js"></script>
+    <script src="https://danzel.github.io/Leaflet.utfgrid/src/leaflet.utfgrid.js"></script>
     <meta charset="utf-8">
     <title>PWD Inlets</title>
-
-    <!-- External Stylesheets -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
-
-    <!-- Add the Leaflet JavaScript library -->
-    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
+    <style>
+        #map {
+            width:100%;
+            height:500px;
+        }
+    </style>
 </head>
-
 <body>
-    <div class="container">
-        <h3>PWD Inlets</h3>
-        <div id="map" style="width: 705px; height: 375px"></div>
-    </div>
-<style>
-    #map {
-        border: 1px solid rgba(0, 0, 0, 0);
-        border-radius: 6px;
-        display: inline-block;
-    }
+<select id="inlet-type">
+    <option value='all'>All</option>
+    <option value='a'>A</option>
+    <option value='b'>B</option>
+    <option value='c'>C</option>
+    <option value='d'>D</option>
+</select>
+<div id='map'></div>
 
-    .container {
-        width: 100%;
-        margin-top: 30px;
-        align-content: center;
-        text-align: center;
-    }
-</style>
+
 <script>
-    "use-strict"
 
-    document.addEventListener('DOMContentLoaded', function onload() {
-        // create map object
-        var map = L.map('map', {
-            center: [39.96, -75.15], zoom: 13
-        })
+    //var LAMBNIK_DOMAIN = 'https://d1y4se194ujvw1.cloudfront.net';
+    // If you're running locally and want to test, use this host instead
+    var LAMBNIK_DOMAIN = 'http://localhost:9001';
 
-        // add basemap
-        //L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', { attribution: '© OpenStreetMap' }).addTo(map)
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            maxZoom: 19,
-            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-        }).addTo(map);
+    var center = new L.LatLng(39.95, -75.15),
+        map = new L.Map('map', {center: center, zoom: 13}),
+        baselayer = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png').addTo(map),
+        tileLayer = L.tileLayer(LAMBNIK_DOMAIN + '/tile/{z}/{x}/{y}?type={type}', {
+            type: function() {
+                return document.getElementById('inlet-type').value;
+            }}).addTo(map);
 
+    var grid = new L.UtfGrid(LAMBNIK_DOMAIN + '/grid/{z}/{x}/{y}?type={type}', {
+        useJsonP: false,
+        type: function() {
+            return document.getElementById('inlet-type').value;
+        }
+    });
 
-        // add tileserver
-        // un-comment out the path that you want to test
-        var TILESERVER_PATH = 'https://d28f32z0lbuk2f.cloudfront.net//tile/{z}/{x}/{y}.png'
-        // var TILESERVER_PATH = 'http://localhost:9001/tile/{z}/{x}/{y}.png'
-        L.tileLayer(TILESERVER_PATH).addTo(map)
-    })
+    map.addLayer(grid);
 
+    grid.on('click', function(e) {
+        if (e.data) {
+            alert(e.data.inlettype);
+        }
+    });
+
+    document.addEventListener('DOMContentLoaded',function() {
+
+        document.getElementById('inlet-type').onchange = function(e) {
+            map.removeLayer(tileLayer);
+            map.removeLayer(grid);
+            map.addLayer(tileLayer);
+            map.addLayer(grid);
+        };
+    });
 </script>
 </body>
-
 </html>

--- a/node_lambnik/src/demo/pwd_inlets_index.html
+++ b/node_lambnik/src/demo/pwd_inlets_index.html
@@ -54,14 +54,14 @@
         L.tileLayer(TILESERVER_PATH + '/tile/{z}/{x}/{y}.png').addTo(map);
 
         // add utf grid
-        var grid = new L.UtfGrid(TILESERVER_PATH + "/grid/owner/{z}/{x}/{y}", {
+        var grid = new L.UtfGrid(TILESERVER_PATH + "/grid/{z}/{x}/{y}?utfFields=inlettype,owner", {
             useJsonP: false
         });
 
         map.addLayer(grid);
         grid.on('click', function(e) {
             if (e.data) {
-                alert("This inlet is owned by: " + e.data.owner);
+                alert("This inlet is owned by: " + e.data.owner + " and has type " + e.data.inlettype);
                 console.log(JSON.stringify(e.data))
             }
         });

--- a/node_lambnik/src/demo/pwd_inlets_index.html
+++ b/node_lambnik/src/demo/pwd_inlets_index.html
@@ -54,14 +54,14 @@
         L.tileLayer(TILESERVER_PATH + '/tile/{z}/{x}/{y}.png').addTo(map);
 
         // add utf grid
-        var grid = new L.UtfGrid(TILESERVER_PATH + "/grid/inlettype/{z}/{x}/{y}", {
+        var grid = new L.UtfGrid(TILESERVER_PATH + "/grid/owner/{z}/{x}/{y}", {
             useJsonP: false
         });
 
         map.addLayer(grid);
         grid.on('click', function(e) {
             if (e.data) {
-                alert("This inlet if of type: " + e.data.inlettype);
+                alert("This inlet is owned by: " + e.data.owner);
                 console.log(JSON.stringify(e.data))
             }
         });

--- a/node_lambnik/src/demo/pwd_inlets_index.html
+++ b/node_lambnik/src/demo/pwd_inlets_index.html
@@ -54,7 +54,7 @@
         L.tileLayer(TILESERVER_PATH + '/tile/{z}/{x}/{y}.png').addTo(map);
 
         // add utf grid
-        var grid = new L.UtfGrid(TILESERVER_PATH + "/grid/{z}/{x}/{y}", {
+        var grid = new L.UtfGrid(TILESERVER_PATH + "/grid/inlettype/{z}/{x}/{y}", {
             useJsonP: false
         });
 

--- a/node_lambnik/src/tiler/src/path-config.js
+++ b/node_lambnik/src/tiler/src/path-config.js
@@ -4,6 +4,6 @@
 
 export const USAGE_PATH = '/'
 export const TILE_PATH = '/tile/{z}/{x}/{y}'
-export const GRID_PATH = '/grid/{infocolumn}/{z}/{x}/{y}'
+export const GRID_PATH = '/grid/{z}/{x}/{y}'
 export const FAVICON_PATH = '/favicon.ico'
 export const IMAGE_TEST_PATH = '/img'

--- a/node_lambnik/src/tiler/src/path-config.js
+++ b/node_lambnik/src/tiler/src/path-config.js
@@ -4,6 +4,6 @@
 
 export const USAGE_PATH = '/'
 export const TILE_PATH = '/tile/{z}/{x}/{y}'
-export const GRID_PATH = '/grid/{z}/{x}/{y}'
+export const GRID_PATH = '/grid/{infocolumn}/{z}/{x}/{y}'
 export const FAVICON_PATH = '/favicon.ico'
 export const IMAGE_TEST_PATH = '/img'

--- a/node_lambnik/src/tiler/src/res/point-vector.xml
+++ b/node_lambnik/src/tiler/src/res/point-vector.xml
@@ -3,7 +3,7 @@
     <Style name="point" filter-mode="first">
 
         <Rule>
-            <MarkersSymbolizer fill="black" width="3" placement="point" marker-type="square" allow-overlap="true"/>
+            <MarkersSymbolizer fill="black" width="5" placement="point" marker-type="square" allow-overlap="true"/>
         </Rule>
 
     </Style>

--- a/node_lambnik/src/tiler/src/tile-interface.js
+++ b/node_lambnik/src/tiler/src/tile-interface.js
@@ -42,15 +42,22 @@ export const img = () => new Promise((resolve, reject) => {
     })
 })
 
+// makes sure the utf query string is properly formatted
+const processUTFQuery = (queryString) => {
+    if (!queryString) throw new Error('UTF grid missing field query!')
+
+    return queryString.split(',')
+}
+
 export const getGrid = (req) => {
     // Handle url params
     const z = Number(req.pathParams.z)
     const x = Number(req.pathParams.x)
     const y = Number(req.pathParams.y)
-    const infoColumn = req.pathParams.infocolumn
+    const utfFields = processUTFQuery(req.queryString.utfFields)
 
     // create grid
-    return grid(z, x, y, infoColumn)
+    return grid(z, x, y, utfFields)
         .then(result => result)
         .catch(e => JSON.stringify(e))
 }

--- a/node_lambnik/src/tiler/src/tile-interface.js
+++ b/node_lambnik/src/tiler/src/tile-interface.js
@@ -47,9 +47,10 @@ export const getGrid = (req) => {
     const z = Number(req.pathParams.z)
     const x = Number(req.pathParams.x)
     const y = Number(req.pathParams.y)
+    const infoColumn = req.pathParams.infocolumn
 
     // create grid
-    return grid(z, x, y)
+    return grid(z, x, y, infoColumn)
         .then(result => result)
         .catch(e => JSON.stringify(e))
 }

--- a/node_lambnik/src/tiler/src/tiler.js
+++ b/node_lambnik/src/tiler/src/tiler.js
@@ -58,14 +58,14 @@ const tileBounds = (z, x, y) => new SphericalMercator().bbox(x, y, z, false, pro
  * @param y
  * @returns {Promise<any>}
  */
-export const grid = (z, x, y) => {
-    const grd = new mapnik.Grid(TILE_WIDTH, TILE_HEIGHT, {key: 'inlettype'})
+export const grid = (z, x, y, infoColumn) => {
+    const grd = new mapnik.Grid(TILE_WIDTH, TILE_HEIGHT, {key: infoColumn})
 
     return createMap(z, x, y)
         .then((map) => new Promise((resolve, reject) => {
             map.render(grd, {
                 layer: 0,
-                fields: ['inlettype'],
+                fields: [ infoColumn ],
             }, (err, rendered) => {
                 if (err) reject(err)
                 else resolve(rendered)

--- a/node_lambnik/src/tiler/src/tiler.js
+++ b/node_lambnik/src/tiler/src/tiler.js
@@ -58,14 +58,14 @@ const tileBounds = (z, x, y) => new SphericalMercator().bbox(x, y, z, false, pro
  * @param y
  * @returns {Promise<any>}
  */
-export const grid = (z, x, y, infoColumn) => {
-    const grd = new mapnik.Grid(TILE_WIDTH, TILE_HEIGHT, {key: infoColumn})
+export const grid = (z, x, y, utfFields) => {
+    const grd = new mapnik.Grid(TILE_WIDTH, TILE_HEIGHT)
 
     return createMap(z, x, y)
         .then((map) => new Promise((resolve, reject) => {
             map.render(grd, {
                 layer: 0,
-                fields: [ infoColumn ],
+                fields: utfFields,
             }, (err, rendered) => {
                 if (err) reject(err)
                 else resolve(rendered)

--- a/node_lambnik/src/tiler/src/tiler.js
+++ b/node_lambnik/src/tiler/src/tiler.js
@@ -59,27 +59,33 @@ const tileBounds = (z, x, y) => new SphericalMercator().bbox(x, y, z, false, pro
  * @returns {Promise<any>}
  */
 export const grid = (z, x, y) => {
-    const grd = new mapnik.Grid(TILE_WIDTH, TILE_HEIGHT)
+    const grd = new mapnik.Grid(TILE_WIDTH, TILE_HEIGHT, {key: 'inlettype'})
 
     return createMap(z, x, y)
         .then((map) => new Promise((resolve, reject) => {
             map.render(grd, {
                 layer: 0,
                 fields: ['inlettype'],
-            }, (err, _grd) => {
-                if (err) fail(err)
-
-                return _grd.encode('utf', {
-                    resolution: 4,
-                })
+            }, (err, rendered) => {
+                if (err) reject(err)
+                else resolve(rendered)
             })
         }))
+        .then((g) => {
+            return new Promise((resolve, reject) => {
+                g.encode({
+                    resolution: 4,
+                }, (err, result) => {
+                    if (err) reject(err)
+                    else resolve(result)
+                })
+            })
+        })
         .then(result => result)
         .catch((e) => {
             console.log(e)
             throw e
         })
-
 }
 
 /**


### PR DESCRIPTION
## Overview

Enables UTF grid support, allowing for map interactivity. The endpoint `/grid/{z}/{x}{y}?utfFields=field1,field2,etc` will serve up UTF grid data based on the values in the database column(s) "fields" (a comma separated list) for the data points in tile z/x/y.


### Demo
![image](https://user-images.githubusercontent.com/16990679/42186415-9a63d9b4-7e1a-11e8-9aa2-04ecdfea37d3.png)


## Testing Instructions

 * Run the local server with `./scripts/update` and `./scripts/server`.
 * Open the demo page at `/src/demo/pwd_inlets_index.html`.
 * Click on a map marker to be shown customizable info about it.


Resolves #11 

