### PR TITLE
Feature/cleanup scripts

### DIFF
--- a/node_lambnik/docker-compose.yml
+++ b/node_lambnik/docker-compose.yml
@@ -39,13 +39,12 @@ services:
       - $HOME/.aws:/root/.aws:ro
 
   terraform:
-    image: hashicorp/terraform:light
+    image: hashicorp/terraform:full
     env_file: .env
     environment:
       - TF_VAR_region=${LAMBDA_REGION}
       - TF_VAR_source_name=${PROJECT_NAME}-${USER}
     working_dir: /home/terraform
-    command: "init"
     volumes:
       - ./src/terraform:/home/terraform
       - $HOME/.aws:/root/.aws:ro

--- a/node_lambnik/env-template
+++ b/node_lambnik/env-template
@@ -16,8 +16,8 @@ PROD_TILEGARDEN_USER=
 LAMBDA_REGION=us-east-1
 
 ## OPTIONAL ##
-# ARN of role associated with this lambda function
-#LAMBDA_ROLE=arn:aws:iam:1237192731893/role:etc
+# name of role associated with this lambda function
+#LAMBDA_ROLE=role-name
 # Amount of time in seconds your lambdas will wait before timing out
 #LAMBDA_TIMEOUT=5
 # Memory in MB allocated to your lambda functions

--- a/node_lambnik/env-template
+++ b/node_lambnik/env-template
@@ -14,9 +14,10 @@ PROD_TILEGARDEN_USER=
 # Function config information
 ## REQUIRED ##
 LAMBDA_REGION=us-east-1
-LAMBDA_ROLE=role
 
 ## OPTIONAL ##
+# ARN of role associated with this lambda function
+#LAMBDA_ROLE=arn:aws:iam:1237192731893/role:etc
 # Amount of time in seconds your lambdas will wait before timing out
 #LAMBDA_TIMEOUT=5
 # Memory in MB allocated to your lambda functions

--- a/node_lambnik/scripts/clean
+++ b/node_lambnik/scripts/clean
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#!/bin/bash
+
+# Most reliable way to get the path for this script.
+# h/t: https://stackoverflow.com/questions/192292/bash-how-best-to-include-other-scripts/12694189#12694189
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]];
+then
+    DIR="$PWD"
+fi
+
+function usage() {
+    echo -n "Usage: $(basename "$0")
+Clean up unused Docker resources to free disk space.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+    	# Remove build artifacts from local machine
+    	docker-compose run tiler rm -rf bin/ node_modules/
+
+        # Stop containers and shut down the network
+        docker-compose down
+
+        # Remove unused containers, images, and volumes
+        docker images -qf dangling=true | xargs -r docker rmi
+        docker volume ls -qf dangling=true | xargs -r docker volume rm
+        docker ps -a | grep Exit | cut -d ' ' -f 1 | xargs -r docker rm
+
+        docker-compose rm
+    fi
+fi

--- a/node_lambnik/scripts/clean
+++ b/node_lambnik/scripts/clean
@@ -1,14 +1,4 @@
-#!/usr/bin/env bash
-
 #!/bin/bash
-
-# Most reliable way to get the path for this script.
-# h/t: https://stackoverflow.com/questions/192292/bash-how-best-to-include-other-scripts/12694189#12694189
-DIR="${BASH_SOURCE%/*}"
-if [[ ! -d "$DIR" ]];
-then
-    DIR="$PWD"
-fi
 
 function usage() {
     echo -n "Usage: $(basename "$0")
@@ -20,8 +10,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-    	# Remove build artifacts from local machine
-    	docker-compose run tiler rm -rf bin/ node_modules/
+        # Remove build artifacts from local machine
+        docker-compose run tiler rm -rf bin/ node_modules/
 
         # Stop containers and shut down the network
         docker-compose down --volumes

--- a/node_lambnik/scripts/clean
+++ b/node_lambnik/scripts/clean
@@ -12,7 +12,7 @@ fi
 
 function usage() {
     echo -n "Usage: $(basename "$0")
-Clean up unused Docker resources to free disk space.
+Destroy build artifacts and Docker containers for a fresh environment
 "
 }
 
@@ -24,13 +24,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     	docker-compose run tiler rm -rf bin/ node_modules/
 
         # Stop containers and shut down the network
-        docker-compose down
+        docker-compose down --volumes
 
-        # Remove unused containers, images, and volumes
+        # Remove any dangling volumes
         docker images -qf dangling=true | xargs -r docker rmi
         docker volume ls -qf dangling=true | xargs -r docker volume rm
-        docker ps -a | grep Exit | cut -d ' ' -f 1 | xargs -r docker rm
-
-        docker-compose rm
     fi
 fi

--- a/node_lambnik/scripts/destroy
+++ b/node_lambnik/scripts/destroy
@@ -12,6 +12,7 @@ Options:
 
 function main() {
     echo "WARNING: you are about to destroy all your deployed resources!"
+    printf "That includes:\n - Associated AWS Lambda functions\n - Associated API Gateways\n - Associated IAM roles (automatically generated or no)\n - Associated CloudFront distributions\n"
     read -p "If this is what you want, type 'yes' to continue: " -r
     echo
     if [[ $REPLY =~ ^[yY][eE][sS]$ ]]

--- a/node_lambnik/scripts/destroy
+++ b/node_lambnik/scripts/destroy
@@ -16,8 +16,15 @@ function main() {
 	echo
 	if [[ $REPLY =~ ^[yY][eE][sS]$ ]]
 	then
-		docker-compose run tiler yarn destroy;
-		docker-compose run terraform destroy -auto-approve;
+		# This command ALSO tried to destroy your lambda's IAM role.
+		# It will probably fail to do so, but it will delete the lambda
+		# and API Gateway FIRST, so it's fine.
+		docker-compose run tiler yarn destroy || true;
+		docker-compose run tiler rm claudia.json;
+
+		docker-compose run -e TF_VAR_source_id=$(<src/tiler/.api-id) terraform destroy -auto-approve;
+		docker-compose run --entrypoint rm terraform -rf .terraform terraform.tfstate terraform.tfstate.backup;
+
 	else
 		echo "Aborting destroy"
 	fi

--- a/node_lambnik/scripts/destroy
+++ b/node_lambnik/scripts/destroy
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+function usage() {
+    echo -n "Usage: $(basename "${0}")
+Removes all published resources from AWS
+Options:
+    --help      Display this help text
+"
+}
+
+function main() {
+	echo "WARNING: you are about to destroy all your deployed resources!"
+	read -p "If this is what you want, type 'yes' to continue: " -r
+	echo
+	if [[ $REPLY =~ ^[yY][eE][sS]$ ]]
+	then
+		docker-compose run tiler yarn destroy;
+		docker-compose run terraform destroy -auto-approve;
+	else
+		echo "Aborting destroy"
+	fi
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        main
+    fi
+    exit
+fi

--- a/node_lambnik/scripts/destroy
+++ b/node_lambnik/scripts/destroy
@@ -20,7 +20,7 @@ function main() {
 		# It will probably fail to do so, but it will delete the lambda
 		# and API Gateway FIRST, so it's fine.
 		docker-compose run tiler yarn destroy || true;
-		docker-compose run tiler rm claudia.json;
+		docker-compose run tiler rm claudia.json .api-id;
 
 		docker-compose run -e TF_VAR_source_id=$(<src/tiler/.api-id) terraform destroy -auto-approve;
 		docker-compose run --entrypoint rm terraform -rf .terraform terraform.tfstate terraform.tfstate.backup;

--- a/node_lambnik/scripts/destroy
+++ b/node_lambnik/scripts/destroy
@@ -19,9 +19,9 @@ function main() {
     then
 
         # Destroy deployed resources
-        # This command ALSO tried to destroy your lambda's IAM role.
-        # It will probably fail to do so, but it will delete the lambda
-        # and API Gateway FIRST, so it's fine.
+        # If any part of this fails, the parts that didn't fail
+        # remain destroyed, so it's best to just carry on and
+        # follow through.
         docker-compose run tiler yarn destroy || true
         docker-compose run -e TF_VAR_source_id=$(<src/tiler/.api-id) terraform destroy -auto-approve
 

--- a/node_lambnik/scripts/destroy
+++ b/node_lambnik/scripts/destroy
@@ -16,13 +16,16 @@ function main() {
 	echo
 	if [[ $REPLY =~ ^[yY][eE][sS]$ ]]
 	then
+
+		# Destroy deployed resources
 		# This command ALSO tried to destroy your lambda's IAM role.
 		# It will probably fail to do so, but it will delete the lambda
 		# and API Gateway FIRST, so it's fine.
 		docker-compose run tiler yarn destroy || true;
-		docker-compose run tiler rm claudia.json .api-id;
-
 		docker-compose run -e TF_VAR_source_id=$(<src/tiler/.api-id) terraform destroy -auto-approve;
+
+		# Remove local config files
+		docker-compose run tiler rm claudia.json .api-id;
 		docker-compose run --entrypoint rm terraform -rf .terraform terraform.tfstate terraform.tfstate.backup;
 
 	else

--- a/node_lambnik/scripts/destroy
+++ b/node_lambnik/scripts/destroy
@@ -11,26 +11,26 @@ Options:
 }
 
 function main() {
-	echo "WARNING: you are about to destroy all your deployed resources!"
-	read -p "If this is what you want, type 'yes' to continue: " -r
-	echo
-	if [[ $REPLY =~ ^[yY][eE][sS]$ ]]
-	then
+    echo "WARNING: you are about to destroy all your deployed resources!"
+    read -p "If this is what you want, type 'yes' to continue: " -r
+    echo
+    if [[ $REPLY =~ ^[yY][eE][sS]$ ]]
+    then
 
-		# Destroy deployed resources
-		# This command ALSO tried to destroy your lambda's IAM role.
-		# It will probably fail to do so, but it will delete the lambda
-		# and API Gateway FIRST, so it's fine.
-		docker-compose run tiler yarn destroy || true;
-		docker-compose run -e TF_VAR_source_id=$(<src/tiler/.api-id) terraform destroy -auto-approve;
+        # Destroy deployed resources
+        # This command ALSO tried to destroy your lambda's IAM role.
+        # It will probably fail to do so, but it will delete the lambda
+        # and API Gateway FIRST, so it's fine.
+        docker-compose run tiler yarn destroy || true
+        docker-compose run -e TF_VAR_source_id=$(<src/tiler/.api-id) terraform destroy -auto-approve
 
-		# Remove local config files
-		docker-compose run tiler rm claudia.json .api-id;
-		docker-compose run --entrypoint rm terraform -rf .terraform terraform.tfstate terraform.tfstate.backup;
+        # Remove local config files
+        docker-compose run tiler rm claudia.json .api-id
+        docker-compose run --entrypoint rm terraform -rf .terraform terraform.tfstate terraform.tfstate.backup
 
-	else
-		echo "Aborting destroy"
-	fi
+    else
+        echo "Aborting destroy"
+    fi
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]

--- a/node_lambnik/scripts/publish
+++ b/node_lambnik/scripts/publish
@@ -14,9 +14,9 @@ Options:
 function main() {
     if [ "${1}" = "--new" ]
     then
-        docker-compose run -e NODE_ENV=production --rm tiler yarn deploy-new
+        docker-compose run --rm -e NODE_ENV=production tiler yarn deploy-new
     else
-        docker-compose run -e NODE_ENV=production --rm tiler yarn deploy
+        docker-compose run --rm -e NODE_ENV=production tiler yarn deploy
     fi
 
 	# Deploy CloudFront proxy

--- a/node_lambnik/scripts/publish
+++ b/node_lambnik/scripts/publish
@@ -14,14 +14,14 @@ Options:
 function main() {
     if [ "${1}" = "--new" ]
     then
-        docker-compose run -e NODE_ENV=production tiler yarn deploy-new
+        docker-compose run -e NODE_ENV=production --rm tiler yarn deploy-new
     else
-        docker-compose run -e NODE_ENV=production tiler yarn deploy
+        docker-compose run -e NODE_ENV=production --rm tiler yarn deploy
     fi
 
 	# Deploy CloudFront proxy
 	docker-compose run terraform init
-	docker-compose run -e TF_VAR_source_id=$(<src/tiler/.api-id) terraform apply -auto-approve && \
+	docker-compose run --rm -e TF_VAR_source_id=$(<src/tiler/.api-id) terraform apply -auto-approve && \
 	echo "Success! Your tiles will be available at the above URL shortly."
 }
 

--- a/node_lambnik/src/tiler/package.json
+++ b/node_lambnik/src/tiler/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build-xml": "babel-node src/util/build-xml.js src/config/map-config.mml bin/map-config.xml",
     "deploy": "yarn transpile && claudia update ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}}",
-    "deploy-new": "yarn transpile && claudia create --api-module bin/api --name ${PROJECT_NAME} --region ${LAMBDA_REGION} --role ${LAMBDA_ROLE} ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}} && yarn parse-id",
+    "deploy-new": "yarn transpile && claudia create --api-module bin/api --name ${PROJECT_NAME} --region ${LAMBDA_REGION} ${LAMBDA_ROLE:+--role ${LAMBDA_ROLE}} ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}} && yarn parse-id",
     "destroy": "claudia destroy",
     "dev": "nodemon -e js,mss,json,mml,mss --ignore bin/ --exec yarn local",
     "lint": "eslint src",

--- a/node_lambnik/src/tiler/package.json
+++ b/node_lambnik/src/tiler/package.json
@@ -26,6 +26,7 @@
     "build-xml": "babel-node src/util/build-xml.js src/config/map-config.mml bin/map-config.xml",
     "deploy": "yarn transpile && claudia update ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}}",
     "deploy-new": "yarn transpile && claudia create --api-module bin/api --name ${PROJECT_NAME} --region ${LAMBDA_REGION} --role ${LAMBDA_ROLE} ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}} && yarn parse-id",
+    "destroy": "claudia destroy",
     "dev": "nodemon -e js,mss,json,mml,mss --ignore bin/ --exec yarn local",
     "lint": "eslint src",
     "local": "yarn transpile && node --inspect=0.0.0.0:9229 node_modules/claudia-local-api/bin/claudia-local-api --api-module bin/api | bunyan -o short",


### PR DESCRIPTION
## Overview

This PR adds two scripts, `destroy`, which destroys the currently deployed AWS resources, and `clean`, which deletes local development environment-created files (such as `node_modules/` and downed Docker containers).


### Demo
```
WARNING: you are about to destroy all your deployed resources!
If this is what you want, type 'yes' to continue: yes

Starting nodelambnik_database_1 ... done
yarn run v1.5.1
$ claudia destroy
{ AccessDenied: User: arn:aws:iam::279682201306:user/mdelsordo is not authorized to perform: iam:DeleteRolePolicy on resource: role lambnik-tiler-dev
    at Request.extractError (/home/tiler/node_modules/aws-sdk/lib/protocol/query.js:47:29)
    at Request.callListeners (/home/tiler/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/home/tiler/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/tiler/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/tiler/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/tiler/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/tiler/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/tiler/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/home/tiler/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/home/tiler/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
  message: 'User: arn:aws:iam::279682201306:user/mdelsordo is not authorized to perform: iam:DeleteRolePolicy on resource: role lambnik-tiler-dev',
  code: 'AccessDenied',
  time: 2018-07-09T15:38:02.402Z,
  requestId: '10b545b1-838e-11e8-b203-1933c93aab81',
  statusCode: 403,
  retryable: false,
  retryDelay: 26.99817764686927 }
error An unexpected error occurred: "Command failed.
Exit code: 1
Command: sh
Arguments: -c claudia destroy
Directory: /home/tiler
Output:
".
info If you think this is a bug, please open a bug report with the information provided in "/home/tiler/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Starting nodelambnik_database_1 ... done
./scripts/destroy: line 25: src/tiler/.api-id: No such file or directory
aws_cloudfront_distribution.tilegarden_test: Refreshing state... (ID: E1SLZVWI7WGQ9N)
aws_cloudfront_distribution.tilegarden_test: Destroying... (ID: E1SLZVWI7WGQ9N)
aws_cloudfront_distribution.tilegarden_test: Still destroying... (ID: E1SLZVWI7WGQ9N, 10s elapsed)
...
...
aws_cloudfront_distribution.tilegarden_test: Still destroying... (ID: E1SLZVWI7WGQ9N, 18m20s elapsed)
aws_cloudfront_distribution.tilegarden_test: Still destroying... (ID: E1SLZVWI7WGQ9N, 18m30s elapsed)
aws_cloudfront_distribution.tilegarden_test: Destruction complete after 18m34s

Destroy complete! Resources: 1 destroyed.
```


### Notes

* The final step of Claudia's `destroy` command is to delete all IAM roles associated with the (at this point deleted) lambda. This is not super great for our use case as the `lambnik-tiler-dev` role is shared between various AWS resources. If you don't have the permissions to delete roles (which I don't) the command will fail, but will still have removed the Lambda and API Gateway instances, so the end result is the desired functionality. The trouble comes in when you DO have the permissions to delete roles, and I'm not quite sure how to work around it as `claudia destroy` lacks a ton of configuration options.
* Destroying a CloudFront distribution takes a REALLY long time. I decided to leave the command line output in (rather than running the process in detached mode) so that you can at least get progress updates and not forget about the process before it's complete.


## Testing Instructions
#### (assuming you have already deployed a Tilegarden project and have `claudia.json` and `.api-id` files locally)
 * `destroy`
    * Run `./scripts/destroy`. It will prompt you for confirmation before beginning the process.
    * Wait for the various resources to be removed.
    * All AWS services should be gone along with local config files such as `tiler/claudia.json` and `terraform/terraform.tfstate`.
 * `clean`
    * Run `./scripts/clean`.
    * `tiler/bin/`, `tiler/node_modules/`, and all docker containers should now be removed.

Resolves #44 

