### PR TITLE
Feature/remove lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.zip filter=lfs diff=lfs merge=lfs -text
-*.gz filter=lfs diff=lfs merge=lfs -text

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+git:
+  lfs_skip_smudge: true
 before_install: cd node_lambnik/src/tiler
 install: yarn install
 before_script: yarn transpile

--- a/node_lambnik/data/.gitignore
+++ b/node_lambnik/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/node_lambnik/data/STR_Centerline.zip
+++ b/node_lambnik/data/STR_Centerline.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:67b299968185315d8c13cb71f331e27ea2931111af187f9c5d110b78315b5132
-size 4275471

--- a/node_lambnik/data/pwd_inlets.sql.gz
+++ b/node_lambnik/data/pwd_inlets.sql.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e9d36fc6f51c982bdbfd6bd96f0755308afe76fbf5a0bca427da7055ea35c074
-size 3779091

--- a/node_lambnik/data/pwd_parcels.zip
+++ b/node_lambnik/data/pwd_parcels.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ad815428e367d866a60b78aca5305d8f43764f23b93a6b1f17562b24a156490
-size 85128438

--- a/node_lambnik/docker-compose.yml
+++ b/node_lambnik/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     working_dir: /home
     volumes:
       - ./data:/home/data
-      - ./scripts/updatedb:/home/updatedb
+      - ./scripts/load_sample_data:/home/load_sample_data
 
   tiler:
     build:

--- a/node_lambnik/scripts/fetch-data.sh
+++ b/node_lambnik/scripts/fetch-data.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Fetches development data sets from OpenDataPhilly
+curl 'https://phila-gisdata.s3.amazonaws.com/ODP/STR_Centerline.zip' --output data/STR_Centerline.zip
+curl 'http://gis.phila.gov/gisdata/ODP/PWD_Parcels.zip' --output data/PWD_Parcels.zip
+curl 'https://phl.carto.com/api/v2/sql?q=SELECT+*+FROM+inlets&filename=inlets&format=shp&skipfields=cartodb_id' --output data/inlets.zip

--- a/node_lambnik/scripts/fetch-data.sh
+++ b/node_lambnik/scripts/fetch-data.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
 # Fetches development data sets from OpenDataPhilly
-curl 'https://phila-gisdata.s3.amazonaws.com/ODP/STR_Centerline.zip' -L -o data/STR_Centerline.zip
-curl 'http://gis.phila.gov/gisdata/ODP/PWD_Parcels.zip' -L -o data/PWD_Parcels.zip
-curl 'https://phl.carto.com/api/v2/sql?q=SELECT+*+FROM+inlets&filename=inlets&format=shp&skipfields=cartodb_id' -L -o data/inlets.zip
+if ! [ -f data/STR_Centerline.zip ]; then
+    curl 'https://phila-gisdata.s3.amazonaws.com/ODP/STR_Centerline.zip' -L -o data/STR_Centerline.zip
+fi
+
+if ! [ -f data/PWD_Parcels.zip ]; then
+    curl 'http://gis.phila.gov/gisdata/ODP/PWD_Parcels.zip' -L -o data/PWD_Parcels.zip
+fi
+
+if ! [ -f data/inlets.zip ]; then
+    curl 'https://phl.carto.com/api/v2/sql?q=SELECT+*+FROM+inlets&filename=inlets&format=shp&skipfields=cartodb_id' -L -o data/inlets.zip
+fi

--- a/node_lambnik/scripts/fetch-data.sh
+++ b/node_lambnik/scripts/fetch-data.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # Fetches development data sets from OpenDataPhilly
-if ! [ -f data/STR_Centerline.zip ]; then
-    curl 'https://phila-gisdata.s3.amazonaws.com/ODP/STR_Centerline.zip' -L -o data/STR_Centerline.zip
+if ! [ -f data/street_centerline.zip ]; then
+    curl 'https://phila-gisdata.s3.amazonaws.com/ODP/STR_Centerline.zip' -L -o data/street_centerline.zip
 fi
 
-if ! [ -f data/PWD_Parcels.zip ]; then
-    curl 'http://gis.phila.gov/gisdata/ODP/PWD_Parcels.zip' -L -o data/PWD_Parcels.zip
+if ! [ -f data/pwd_parcels.zip ]; then
+    curl 'http://gis.phila.gov/gisdata/ODP/PWD_Parcels.zip' -L -o data/pwd_parcels.zip
 fi
 
 if ! [ -f data/inlets.zip ]; then

--- a/node_lambnik/scripts/fetch-data.sh
+++ b/node_lambnik/scripts/fetch-data.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 # Fetches development data sets from OpenDataPhilly
-curl 'https://phila-gisdata.s3.amazonaws.com/ODP/STR_Centerline.zip' --output data/STR_Centerline.zip
-curl 'http://gis.phila.gov/gisdata/ODP/PWD_Parcels.zip' --output data/PWD_Parcels.zip
-curl 'https://phl.carto.com/api/v2/sql?q=SELECT+*+FROM+inlets&filename=inlets&format=shp&skipfields=cartodb_id' --output data/inlets.zip
+curl 'https://phila-gisdata.s3.amazonaws.com/ODP/STR_Centerline.zip' -L -o data/STR_Centerline.zip
+curl 'http://gis.phila.gov/gisdata/ODP/PWD_Parcels.zip' -L -o data/PWD_Parcels.zip
+curl 'https://phl.carto.com/api/v2/sql?q=SELECT+*+FROM+inlets&filename=inlets&format=shp&skipfields=cartodb_id' -L -o data/inlets.zip

--- a/node_lambnik/scripts/load_sample_data
+++ b/node_lambnik/scripts/load_sample_data
@@ -150,7 +150,7 @@ check_postgis_install;
 
 for entry in data/*
 do
-	echo "Attempting to add $entry to database"
+    echo "Attempting to add $entry to database"
     file="${entry##*/}"
     base="${file%%.*}"
     add_table "$entry" "$base"

--- a/node_lambnik/scripts/update
+++ b/node_lambnik/scripts/update
@@ -19,8 +19,14 @@ then
             -f docker-compose.yml \
             build
 
+        # Download sample data if flag is set
+        if [ "${1:-}" = "--download" ]
+        then
+            ./scripts/fetch-data.sh
+        fi
+
         # Launch database container so we can populate it.
         docker-compose up -d database
-        docker-compose exec database bash -c "./updatedb"
+        docker-compose exec database bash -c "./load_sample_data"
     fi
 fi

--- a/node_lambnik/scripts/updatedb
+++ b/node_lambnik/scripts/updatedb
@@ -150,6 +150,7 @@ check_postgis_install;
 
 for entry in data/*
 do
+	echo "Attempting to add $entry to database"
     file="${entry##*/}"
     base="${file%%.*}"
     add_table "$entry" "$base"

--- a/node_lambnik/src/demo/datatype-demo.html
+++ b/node_lambnik/src/demo/datatype-demo.html
@@ -16,14 +16,14 @@
     <div id="map" style="width: 800px; height: 800px"></div>
     <div>
         <form id="layer-selector">
-            <input type="radio" name="layer" id="pwd_inlets" value="pwd_inlets">
-            <label for="pwd_inlets">pwd_inlets (POINT/EPSG:4326)</label>
+            <input type="radio" name="layer" id="inlets" value="inlets">
+            <label for="inlets">inlets (POINT/EPSG:4326)</label>
 
             <input type="radio" name="layer" id="street_centerline" value="street_centerline">
             <label for="street_centerline">street_centerline (MULTILINESTRING/EPSG:2272)</label>
 
             <input type="radio" name="layer" id="pwd_parcels" value="pwd_parcels">
-            <label for="pwd_parcels">pwd_parcels (MULTIPOLYGON/EPSG:4326)</label>
+            <label for="pwd_parcels">pwd_parcels (MULTIPOLYGON/EPSG:2272)</label>
         </form>
     </div>
 </div>
@@ -66,7 +66,7 @@
             }
         }
 
-        const layerNames = ['pwd_inlets', 'pwd_parcels', 'street_centerline']
+        const layerNames = ['inlets', 'pwd_parcels', 'street_centerline']
         const layerKeys = Object.assign({}, ...layerNames.map(function(key) {
             return {[key]: createLayer(key)}
         }))

--- a/node_lambnik/src/tiler/src/config/map-config.mml
+++ b/node_lambnik/src/tiler/src/config/map-config.mml
@@ -23,7 +23,7 @@ Layer:
 - id: pwd_parcels
   name: pwd_parcels
   geometry: polygon
-  srs: "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"
+  srs: "+proj=lcc +lat_1=40.96666666666667 +lat_2=39.93333333333333 +lat_0=39.33333333333334 +lon_0=-77.75 +x_0=600000 +y_0=0 +ellps=GRS80 +datum=NAD83 +to_meter=0.3048006096012192 +no_defs"
   Datasource:
     host: ${TILEGARDEN_HOST}
     dbname: ${TILEGARDEN_DB}
@@ -33,8 +33,8 @@ Layer:
     table: "pwd_parcels"
     key_field: ""
     geometry_field: "geom"
-- id: pwd_inlets
-  name: pwd_inlets
+- id: inlets
+  name: inlets
   geometry: polygon
   srs: "+proj=longlat +datum=WGS84 +no_defs"
   Datasource:
@@ -43,6 +43,6 @@ Layer:
     user: ${TILEGARDEN_USER}
     password: ${TILEGARDEN_PASSWORD}
     type: "postgis"
-    table: "pwd_inlets"
+    table: "inlets"
     key_field: ""
     geometry_field: "geom"

--- a/node_lambnik/src/tiler/src/config/style.mss
+++ b/node_lambnik/src/tiler/src/config/style.mss
@@ -10,8 +10,9 @@
     line-color: red;
 }
 
-#pwd_inlets {
-    marker-fill: black;
+#inlets {
+    marker-line-color: purple;
+    marker-fill: lightblue;
     marker-width: 4;
     marker-allow-overlap: true;
 }


### PR DESCRIPTION
## Overview

Using git-lfs to store development data sets cause us to hit GitHub's bandwidth cap very quickly. This PR removes lfs from the project and replaces it with a script that downloads data as `.zip`s directly from OpenDataPhilly.

## Testing Instructions

 * Clear out `/node_modules/data/`.
 * Run `./scripts/fetch-data.sh`.
 * `./scripts/update` should now work as usual.

Resolves #68 

