### PR TITLE
Feature/carto as dev dependency

### DIFF
--- a/node_lambnik/src/tiler/package.json
+++ b/node_lambnik/src/tiler/package.json
@@ -39,6 +39,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
     "bunyan": "^1.8.12",
+    "carto": "^1.0.1",
     "claudia": "^5.0.1",
     "claudia-local-api": "https://github.com/mattdelsordo/claudia-local-api.git#feature/binary-response-support",
     "eslint": "^4.19.1",
@@ -50,7 +51,6 @@
   },
   "dependencies": {
     "babel-runtime": "6",
-    "carto": "^1.0.1",
     "claudia-api-builder": "^4.1.0",
     "jimp": "^0.2.28",
     "mapnik": "^3.7.2",

--- a/node_lambnik/src/tiler/src/api.js
+++ b/node_lambnik/src/tiler/src/api.js
@@ -58,6 +58,7 @@ api.get(
             const layers = processLayers(req)
 
             return image(z, x, y, layers)
+                .catch(e => messageTile(e.toString()))
         } catch (e) {
             return messageTile(e.toString())
         }
@@ -76,6 +77,7 @@ api.get(
             const layers = processLayers(req)
 
             return grid(z, x, y, utfFields, layers)
+                .catch(e => JSON.stringify(e))
         } catch (e) {
             return JSON.stringify(e)
         }

--- a/node_lambnik/src/tiler/src/util/build-xml.js
+++ b/node_lambnik/src/tiler/src/util/build-xml.js
@@ -1,10 +1,14 @@
 /**
  * This script uses carto to compile templated MML files
- * to XML that mapnik can understand
+ * to XML that mapnik can understand. This script is only run prior
+ * to deployment, so it makes use of some devDependencies that won't
+ * exist in production. Under no circumstances should this be
+ * run in production (unless you make Carto a regular dependency).
  */
 
 /* eslint-disable no-console */
 
+/* eslint-disable-next-line import/no-extraneous-dependencies */
 import carto from 'carto'
 import path from 'path'
 import mkdirp from 'mkdirp'


### PR DESCRIPTION
## Overview
The addition of `jimp` to the project pushed the size of the bundle that was being sent to AWS Lambda over AWS Lambda's bundle size cap. To reduce the size of the bundle, this PR makes the `carto` module a devDependency instead of a runtime dependency since it is only ever used to pre-compile MML into XML before the project is deployed.

I've also fixed a error-tile related bug that caused errors generated by the tiler functions to not get caught and return error tiles.

Module size breakdown on `develop`:
![image](https://user-images.githubusercontent.com/16990679/43085497-1f9c1908-8e69-11e8-9505-f6380a205ad1.png)

Content of the resulting error:
> { RequestEntityTooLargeException: Request must be smaller than 69905067 bytes for the CreateFunction operation
    at Object.extractError (/home/tiler/node_modules/aws-sdk/lib/protocol/json.js:48:27)
    at Request.extractError (/home/tiler/node_modules/aws-sdk/lib/protocol/rest_json.js:52:8)
    at Request.callListeners (/home/tiler/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/home/tiler/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/tiler/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/tiler/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/tiler/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/tiler/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/tiler/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/home/tiler/node_modules/aws-sdk/lib/request.js:685:12)
  message: 'Request must be smaller than 69905067 bytes for the CreateFunction operation',
  code: 'RequestEntityTooLargeException',
  time: 2018-07-23T15:14:39.058Z,
  requestId: '0f1d59d0-8e8b-11e8-818b-3d68adb80d1e',
  statusCode: 413,
  retryable: false,
  retryDelay: 11.070712336159506 }

After moving `carto` to devDependencies:
![image](https://user-images.githubusercontent.com/16990679/43085290-9be4beee-8e68-11e8-9b5e-99285bc7d764.png)

`./scripts/publish --new` output:
> {
  "lambda": {
    "role": "tilegarden_carto_dev-mdelsordo-executor",
    "name": "tilegarden_carto_dev-mdelsordo",
    "region": "us-east-1"
  },
  "api": {
    "id": "37b0tdhd11",
    "module": "bin/api",
    "url": "https://37b0tdhd11.execute-api.us-east-1.amazonaws.com/latest"
  }
}
$ jq -r '.api.id' claudia.json > .api-id
Done in 53.41s.

## Testing Instructions

 * Attempt to run `./scripts/publish --new` or `./scripts/publish`, it should publish successfully (unlike on develop).


Resolves #70 

