### PR TITLE
Upgrade claudia-local-api to a version that allows for output reduction

### DIFF
--- a/src/tiler/package.json
+++ b/src/tiler/package.json
@@ -29,7 +29,7 @@
     "destroy": "claudia destroy",
     "dev": "nodemon -e js,mss,json,mml,mss --ignore bin/ --exec yarn local",
     "lint": "eslint src",
-    "local": "yarn transpile && node --inspect=0.0.0.0:9229 node_modules/claudia-local-api/bin/claudia-local-api --api-module bin/api | bunyan -o short",
+    "local": "yarn transpile && node --inspect=0.0.0.0:9229 node_modules/claudia-local-api/bin/claudia-local-api --abbrev 300 --api-module bin/api | bunyan -o short",
     "parse-id": "jq -r '.api.id' claudia.json > .api-id",
     "test": "eslint src && jest --coverage",
     "transpile": "yarn build-xml && babel src -d bin --source-maps inline"
@@ -41,7 +41,7 @@
     "bunyan": "^1.8.12",
     "carto": "^1.0.1",
     "claudia": "^5.0.1",
-    "claudia-local-api": "https://github.com/mattdelsordo/claudia-local-api.git#feature/binary-response-support",
+    "claudia-local-api": "https://github.com/mattdelsordo/claudia-local-api.git",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.12.0",

--- a/src/tiler/yarn.lock
+++ b/src/tiler/yarn.lock
@@ -1197,16 +1197,14 @@ claudia-api-builder@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/claudia-api-builder/-/claudia-api-builder-4.1.1.tgz#9198280c6f5ef19a5fceadf716a819f1d6fc5ce0"
 
-"claudia-local-api@https://github.com/mattdelsordo/claudia-local-api.git#feature/binary-response-support":
+"claudia-local-api@https://github.com/mattdelsordo/claudia-local-api.git":
   version "2.0.0"
-  resolved "https://github.com/mattdelsordo/claudia-local-api.git#15b963e98f17863b54ca028e00855e59f477b0ea"
+  resolved "https://github.com/mattdelsordo/claudia-local-api.git#8f02560c3582ecface1aebdfebdbd1130df7e6ef"
   dependencies:
     body-parser "^1.0.0"
     bunyan "^1.0.0"
     commander "^2.13.0"
     express "^4.16.1"
-    fs "^0.0.1-security"
-    lodash "^4.17.10"
     path-parser "^4.0.4"
 
 claudia@^5.0.1:
@@ -2155,10 +2153,6 @@ fs-readdir-recursive@^1.0.0:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
 
 fsevents@^1.0.0, fsevents@^1.2.2, fsevents@^1.2.3:
   version "1.2.4"


### PR DESCRIPTION
## Overview

I've added another PR to claudia-local-api which implements an `--abbrev` flag which lets the user specify an amount to trim `loggedOuput.body` to. This makes it easier to read the development server logs and noticeably speeds up the development server since it isn't spending so much time printing output.

See the PR I submitted here: https://github.com/suddi/claudia-local-api/pull/20, https://github.com/mattdelsordo/claudia-local-api/pull/4

### Demo

What output tends to look like now with `--abbrev 200`. Normally this body string is over 10k characters long (a 256x256 .png).
```
 19:07:13.775Z  INFO claudia-local-api:
     {
         "statusCode": 200,
         "headers": {
             "Content-Type": "image/png",
             "Access-Control-Allow-Origin": "*",
             "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token",
             "Access-Control-Allow-Methods": "GET,OPTIONS",
             "Access-Control-Allow-Credentials": "true",
             "Access-Control-Max-Age": "0"
        },
         "body": "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAABG6ElEQVR4nO19B5iUVbL26zDMwAw55wwSJElGlJwkqgTFiAEDioqo[...]+BIog6lSvEDcHIQ8hIMEqIcGrqcTTJHyXe4l7UBJ+z3O00+cjYWh7sbi1YT0HDB4f8DG3dx5Umi99kAAAAASUVORK5CYII=",
         "isBase64Encoded": true
     }
```

## Testing Instructions

 * Start the development server with `./scripts/update` and `./scripts/server`.
 * Open up one of the demo pages locally. The resulting logs should be a lot easier on the eyes, and on the server.


Resolves #83 

