### PR TITLE
Feature/multiple config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
  * [About](#About)
  * [Usage](#Usage)
    * [Local Development](#local-development)
+     * [Configuration Selection](#configuration-selection)
      * [Map Styles](#map-styles)
      * [Filters](#filters)
      * [UTF Grids](#utf-grids)
@@ -33,6 +34,10 @@ Dependencies: docker, docker-compose
  * The local development server exposes a node.js debugger, which can be attached to by Chrome DevTools or your IDE of choice [(see below)](#Debugging).
    * (Optional) If you downloaded the example data using `./scripts/update --download`, opening [`index.html`](index.html) (or any of the pages in [`demo/`](demo/)) should show you working demos.
  * The local development environment can be reset by running `./scripts/clean`, which removes all development artifacts including Docker containers and volumes.
+ 
+#### Configuration Selection
+Multiple map configuration `.mml` files can be included in your project's [`src/tiler/src/config`](src/tiler/src/config) to be dynamically loaded at run-time. Use the query string `config` with the name of your configuration file (without the file extension) to select which file gets loaded when rendering tiles. If no `config` is provided, Tilegarden tries to load the config file named `map-config`. 
+ * _Example_: if you have a configuration file named `my-good-map.mml`, you can tell Tilegarden to use it with the endpoint `/tile/{z}/{x}/{y}.png?config=my-good-map`
  
 #### Datasources
 Tilegarden supports the use of any geospatial data source that Mapnik/Carto does (shapefile, postgis, pgraster, raster). However, bear in mind that only PostGIS data sources support custom queries, and are thus the only ones that allow you to perform additional filtering on your data (see [Filters](#filters)). Also, attempting to bundle large local data files into your Tilegarden deployment could lead to rejection by AWS Lambda due to size restrictions.

--- a/demo/filter.html
+++ b/demo/filter.html
@@ -42,7 +42,7 @@
 
             // add filtered layers
             function newLayer (filters) {
-                return L.tileLayer(TILESERVER_PATH + 'tile/{z}/{x}/{y}.png?layers=' + filters)
+                return L.tileLayer(TILESERVER_PATH + 'tile/{z}/{x}/{y}.png?config=point-example&layers=' + filters)
             }
 
             var EXAMPLE_PATH = 'https://yourtiles.cloudfront.net/tile/{z}/{x}/{y}.png?layers='

--- a/demo/raster.html
+++ b/demo/raster.html
@@ -48,7 +48,7 @@
             else TILESERVER_PATH = PROD_PATH;
 
             function makeLayer (layer) {
-                return L.tileLayer(TILESERVER_PATH + 'tile/{z}/{x}/{y}.png?layers=' + layer);
+                return L.tileLayer(TILESERVER_PATH + 'tile/{z}/{x}/{y}.png?config=data-type-example&layers=' + layer);
             }
 
             var currentLayer;

--- a/demo/utf-grid.html
+++ b/demo/utf-grid.html
@@ -41,8 +41,8 @@
             if (!host || host === 'localhost') TILESERVER_PATH = DEV_PATH;
             else TILESERVER_PATH = PROD_PATH;
 
-            L.tileLayer(TILESERVER_PATH + 'tile/{z}/{x}/{y}.png?layers=inlets').addTo(map);
-            var grid = L.utfGrid(TILESERVER_PATH + 'grid/{z}/{x}/{y}?layers=inlets&utfFields=owner,operator', { useJsonP: false })
+            L.tileLayer(TILESERVER_PATH + 'tile/{z}/{x}/{y}.png?config=data-type-example&layers=inlets').addTo(map);
+            var grid = L.utfGrid(TILESERVER_PATH + 'grid/{z}/{x}/{y}?config=data-type-example&layers=inlets&utfFields=owner,operator', { useJsonP: false })
 
             // keep track of currently active marker
             //var marker

--- a/demo/vector.html
+++ b/demo/vector.html
@@ -76,7 +76,7 @@
                     'tilegarden',
                     {
                         type: 'vector',
-                        tiles: [TILESERVER_PATH+'vector/{z}/{x}/{y}']
+                        tiles: [TILESERVER_PATH+'vector/{z}/{x}/{y}?config=data-type-example']
                     },
                 )
                 map.addLayer(layers['inlets'])

--- a/src/tiler/package.json
+++ b/src/tiler/package.json
@@ -23,7 +23,7 @@
     "bin"
   ],
   "scripts": {
-    "build-xml": "babel-node src/util/build-xml.js src/config/map-config.mml bin/map-config.xml",
+    "build-xml": "babel-node src/util/build-xml.js src/config/ bin/config/",
     "deploy": "yarn transpile && claudia update ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}}",
     "deploy-new": "yarn transpile && claudia create --api-module bin/api --name ${PROJECT_NAME} --region ${LAMBDA_REGION} ${LAMBDA_ROLE:+--role ${LAMBDA_ROLE}} ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}} && yarn parse-id",
     "destroy": "claudia destroy",
@@ -32,7 +32,7 @@
     "local": "yarn transpile && node --inspect=0.0.0.0:9229 node_modules/claudia-local-api/bin/claudia-local-api --api-module bin/api | bunyan -o short",
     "parse-id": "jq -r '.api.id' claudia.json > .api-id",
     "test": "eslint src && jest --coverage",
-    "transpile": "yarn build-xml && babel src -d bin --copy-files --source-maps inline"
+    "transpile": "yarn build-xml && babel src -d bin --source-maps inline"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/tiler/src/api.js
+++ b/src/tiler/src/api.js
@@ -66,8 +66,9 @@ api.get(
         try {
             const { z, x, y } = processCoords(req)
             const layers = processLayers(req)
+            const { config } = req.queryString
 
-            return image(z, x, y, layers)
+            return image(z, x, y, layers, config)
                 .catch(e => messageTile(e.toString()))
         } catch (e) {
             return messageTile(e.toString())
@@ -85,8 +86,9 @@ api.get(
             const { z, x, y } = processCoords(req)
             const utfFields = processUTFQuery(req)
             const layers = processLayers(req)
+            const { config } = req.queryString
 
-            return grid(z, x, y, utfFields, layers)
+            return grid(z, x, y, utfFields, layers, config)
                 .catch(e => JSON.stringify(e))
         } catch (e) {
             return JSON.stringify(e)
@@ -100,8 +102,9 @@ api.get(
     (req) => {
         const { z, x, y } = processCoords(req)
         const layers = processLayers(req)
+        const { config } = req.queryString
 
-        return vectorTile(z, x, y, layers)
+        return vectorTile(z, x, y, layers, config)
     },
     VECTOR_RESPONSE,
 )

--- a/src/tiler/src/config/data-type-example-style.mss
+++ b/src/tiler/src/config/data-type-example-style.mss
@@ -1,0 +1,18 @@
+#pwd_parcels {
+    marker-fill: black;
+    marker-width: 1;
+    marker-allow-overlap: true;
+    line-color: red;
+    polygon-fill: orange;
+}
+
+#street_centerline{
+    line-color: red;
+}
+
+#inlets {
+    marker-line-color: red;
+    marker-fill: orange;
+    marker-width: 8;
+    marker-allow-overlap: true;
+}

--- a/src/tiler/src/config/data-type-example.mml
+++ b/src/tiler/src/config/data-type-example.mml
@@ -4,7 +4,7 @@ srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=
 format: png
 
 Stylesheet:
-  - style.mss
+  - data-type-example-style.mss
 
 Layer:
 - id: street_centerline

--- a/src/tiler/src/config/point-example-style.mss
+++ b/src/tiler/src/config/point-example-style.mss
@@ -1,0 +1,63 @@
+#STATE {
+    marker-fill: gold;
+    marker-line-color: blue;
+    marker-width: 4;
+    marker-allow-overlap: true;
+}
+#PWD {
+    marker-fill: lightblue;
+    marker-line-color: blue;
+    marker-width: 4;
+    marker-allow-overlap: true;
+}
+#PARK {
+    marker-fill: lightgreen;
+    marker-line-color: green;
+    marker-width: 4;
+    marker-allow-overlap: true;
+}
+#AIRPRT {
+    marker-fill: white;
+    marker-line-color: grey;
+    marker-width: 4;
+    marker-allow-overlap: true;
+}
+
+#LM {
+    marker-fill: yellow;
+    marker-line-color: black;
+    marker-width: 4;
+    marker-allow-overlap: true;
+}
+
+#FEDERAL {
+    marker-fill: red;
+    marker-line-color: blue;
+    marker-width: 4;
+    marker-allow-overlap: true;
+}
+
+#PRIV {
+    marker-fill: yellow;
+    marker-line-color: green;
+    marker-width: 4;
+    marker-allow-overlap: true;
+}
+#CHEL {
+    marker-fill: brown;
+    marker-line-color: grey;
+    marker-width: 4;
+    marker-allow-overlap: true;
+}
+#USNAVY {
+    marker-fill: blue;
+    marker-line-color: gold;
+    marker-width: 4;
+    marker-allow-overlap: true;
+}
+#PRIVPWDMAINT {
+    marker-fill: brown;
+    marker-line-color: grey;
+    marker-width: 4;
+    marker-allow-overlap: true;
+}

--- a/src/tiler/src/config/point-example.mml
+++ b/src/tiler/src/config/point-example.mml
@@ -1,0 +1,139 @@
+name: Tilegarden Configuration
+description: Carto MML file to configure Tilegarden settings
+srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs
+format: png
+
+Stylesheet:
+  - point-example-style.mss
+
+Layer:
+- id: PWD
+  name: PWD
+  geometry: polygon
+  srs: "+proj=longlat +datum=WGS84 +no_defs"
+  Datasource:
+     host: ${TILEGARDEN_HOST}
+     dbname: ${TILEGARDEN_DB}
+     user: ${TILEGARDEN_USER}
+     password: ${TILEGARDEN_PASSWORD}
+     type: "postgis"
+     table: "(select geom,owner,inlettype from inlets where owner = 'PWD') as q"
+     key_field: ""
+     geometry_field: "geom"
+- id: AIRPRT
+  name: AIRPRT
+  geometry: polygon
+  srs: "+proj=longlat +datum=WGS84 +no_defs"
+  Datasource:
+     host: ${TILEGARDEN_HOST}
+     dbname: ${TILEGARDEN_DB}
+     user: ${TILEGARDEN_USER}
+     password: ${TILEGARDEN_PASSWORD}
+     type: "postgis"
+     table: "(select geom,owner,inlettype from inlets where owner = 'AIRPRT') as q"
+     key_field: ""
+     geometry_field: "geom"
+- id: STATE
+  name: STATE
+  geometry: polygon
+  srs: "+proj=longlat +datum=WGS84 +no_defs"
+  Datasource:
+     host: ${TILEGARDEN_HOST}
+     dbname: ${TILEGARDEN_DB}
+     user: ${TILEGARDEN_USER}
+     password: ${TILEGARDEN_PASSWORD}
+     type: "postgis"
+     table: "(select geom,owner,inlettype from inlets where owner = 'STATE') as q"
+     key_field: ""
+     geometry_field: "geom"
+- id: PARK
+  name: PARK
+  geometry: polygon
+  srs: "+proj=longlat +datum=WGS84 +no_defs"
+  Datasource:
+     host: ${TILEGARDEN_HOST}
+     dbname: ${TILEGARDEN_DB}
+     user: ${TILEGARDEN_USER}
+     password: ${TILEGARDEN_PASSWORD}
+     type: "postgis"
+     table: "(select geom,owner,inlettype from inlets where owner = 'PARK') as q"
+     key_field: ""
+     geometry_field: "geom"
+- id: LM
+  name: LM
+  geometry: polygon
+  srs: "+proj=longlat +datum=WGS84 +no_defs"
+  Datasource:
+     host: ${TILEGARDEN_HOST}
+     dbname: ${TILEGARDEN_DB}
+     user: ${TILEGARDEN_USER}
+     password: ${TILEGARDEN_PASSWORD}
+     type: "postgis"
+     table: "(select geom,owner,inlettype from inlets where owner = 'LM') as q"
+     key_field: ""
+     geometry_field: "geom"
+- id: FEDERAL
+  name: FEDERAL
+  geometry: polygon
+  srs: "+proj=longlat +datum=WGS84 +no_defs"
+  Datasource:
+     host: ${TILEGARDEN_HOST}
+     dbname: ${TILEGARDEN_DB}
+     user: ${TILEGARDEN_USER}
+     password: ${TILEGARDEN_PASSWORD}
+     type: "postgis"
+     table: "(select geom,owner,inlettype from inlets where owner = 'FEDERAL') as q"
+     key_field: ""
+     geometry_field: "geom"
+- id: PRIV
+  name: PRIV
+  geometry: polygon
+  srs: "+proj=longlat +datum=WGS84 +no_defs"
+  Datasource:
+     host: ${TILEGARDEN_HOST}
+     dbname: ${TILEGARDEN_DB}
+     user: ${TILEGARDEN_USER}
+     password: ${TILEGARDEN_PASSWORD}
+     type: "postgis"
+     table: "(select geom,owner,inlettype from inlets where owner = 'PRIV') as q"
+     key_field: ""
+     geometry_field: "geom"
+- id: CHEL
+  name: CHEL
+  geometry: polygon
+  srs: "+proj=longlat +datum=WGS84 +no_defs"
+  Datasource:
+     host: ${TILEGARDEN_HOST}
+     dbname: ${TILEGARDEN_DB}
+     user: ${TILEGARDEN_USER}
+     password: ${TILEGARDEN_PASSWORD}
+     type: "postgis"
+     table: "(select geom,owner,inlettype from inlets where owner = 'CHEL') as q"
+     key_field: ""
+     geometry_field: "geom"
+- id: USNAVY
+  name: USNAVY
+  geometry: polygon
+  srs: "+proj=longlat +datum=WGS84 +no_defs"
+  Datasource:
+     host: ${TILEGARDEN_HOST}
+     dbname: ${TILEGARDEN_DB}
+     user: ${TILEGARDEN_USER}
+     password: ${TILEGARDEN_PASSWORD}
+     type: "postgis"
+     table: "(select geom,owner,inlettype from inlets where owner = 'USNAVY') as q"
+     key_field: ""
+     geometry_field: "geom"
+- id: PRIVPWDMAINT
+  name: PRIVPWDMAINT
+  geometry: polygon
+  srs: "+proj=longlat +datum=WGS84 +no_defs"
+  Datasource:
+     host: ${TILEGARDEN_HOST}
+     dbname: ${TILEGARDEN_DB}
+     user: ${TILEGARDEN_USER}
+     password: ${TILEGARDEN_PASSWORD}
+     type: "postgis"
+     table: "(select geom,owner,inlettype from inlets where owner = 'PRIVPWDMAINT') as q"
+     key_field: ""
+     geometry_field: "geom"

--- a/src/tiler/src/config/style.mss
+++ b/src/tiler/src/config/style.mss
@@ -1,82 +1,15 @@
 #pwd_parcels {
-    marker-fill: black;
-    marker-width: 1;
-    marker-allow-overlap: true;
-    line-color: red;
-    polygon-fill: orange;
+    line-color: darkgrey;
+    polygon-fill: white;
 }
 
 #street_centerline{
-    line-color: red;
+    line-color: grey;
 }
 
 #inlets {
-    marker-line-color: red;
-    marker-fill: orange;
-    marker-width: 8;
-    marker-allow-overlap: true;
-}
-
-#STATE {
-    marker-fill: gold;
-    marker-line-color: blue;
-    marker-width: 4;
-    marker-allow-overlap: true;
-}
-#PWD {
-    marker-fill: lightblue;
-    marker-line-color: blue;
-    marker-width: 4;
-    marker-allow-overlap: true;
-}
-#PARK {
-    marker-fill: lightgreen;
-    marker-line-color: green;
-    marker-width: 4;
-    marker-allow-overlap: true;
-}
-#AIRPRT {
-    marker-fill: white;
-    marker-line-color: grey;
-    marker-width: 4;
-    marker-allow-overlap: true;
-}
-
-#LM {
-    marker-fill: yellow;
     marker-line-color: black;
-    marker-width: 4;
-    marker-allow-overlap: true;
-}
-
-#FEDERAL {
-    marker-fill: red;
-    marker-line-color: blue;
-    marker-width: 4;
-    marker-allow-overlap: true;
-}
-
-#PRIV {
-    marker-fill: yellow;
-    marker-line-color: green;
-    marker-width: 4;
-    marker-allow-overlap: true;
-}
-#CHEL {
-    marker-fill: brown;
-    marker-line-color: grey;
-    marker-width: 4;
-    marker-allow-overlap: true;
-}
-#USNAVY {
-    marker-fill: blue;
-    marker-line-color: gold;
-    marker-width: 4;
-    marker-allow-overlap: true;
-}
-#PRIVPWDMAINT {
-    marker-fill: brown;
-    marker-line-color: grey;
-    marker-width: 4;
+    marker-fill: white;
+    marker-width: 8;
     marker-allow-overlap: true;
 }

--- a/src/tiler/src/tiler.js
+++ b/src/tiler/src/tiler.js
@@ -25,13 +25,15 @@ mapnik.register_default_input_plugins()
  * @param y
  * @returns {Promise<mapnik.Map>}
  */
-const createMap = (z, x, y, layers) => {
+const createMap = (z, x, y, layers, config = 'map-config') => {
     // Create a webmercator map with specified bounds
     const map = new mapnik.Map(TILE_WIDTH, TILE_HEIGHT)
     map.bufferSize = 64
 
+    const configName = path.join(__dirname, `config/${config}.xml`)
+
     // Load map specification from xml string
-    return readFile(path.join(__dirname, 'map-config.xml'), 'utf-8')
+    return readFile(configName, 'utf-8')
         .then(xml => filterVisibleLayers(xml, layers))
         .then(xml => new Promise((resolve, reject) => {
             map.fromString(xml, (err, result) => {
@@ -65,13 +67,13 @@ const encodeAsPNG = renderedTile => new Promise((resolve, reject) => {
  * @param y
  * @returns {Promise<any>}
  */
-export const image = (z, x, y, layers) => {
+export const image = (z, x, y, layers, config) => {
     // create mapnik image
     const img = new mapnik.Image(TILE_WIDTH, TILE_HEIGHT)
 
     // render map to image
     // return asynchronous rendering method as a promise
-    return createMap(z, x, y, layers)
+    return createMap(z, x, y, layers, config)
         .then(map => new Promise((resolve, reject) => {
             map.render(img, {}, (err, result) => {
                 if (err) reject(err)
@@ -92,10 +94,10 @@ export const image = (z, x, y, layers) => {
  * @param y
  * @returns {Promise<any>}
  */
-export const grid = (z, x, y, utfFields, layers) => {
+export const grid = (z, x, y, utfFields, layers, config) => {
     const grd = new mapnik.Grid(TILE_WIDTH, TILE_HEIGHT)
 
-    return createMap(z, x, y, layers)
+    return createMap(z, x, y, layers, config)
         .then(map => new Promise((resolve, reject) => {
             map.render(grd, {
                 layer: 0,
@@ -128,10 +130,10 @@ export const grid = (z, x, y, utfFields, layers) => {
  * @param layers
  * @returns {Promise<mapnik.Buffer>}
  */
-export const vectorTile = (z, x, y, layers) => {
+export const vectorTile = (z, x, y, layers, config) => {
     const vt = new mapnik.VectorTile(z, x, y)
 
-    return createMap(z, x, y, layers)
+    return createMap(z, x, y, layers, config)
         .then(map => new Promise((resolve, reject) => {
             map.render(vt, (err, tile) => {
                 if (err) reject(err)

--- a/src/tiler/src/util/build-xml.js
+++ b/src/tiler/src/util/build-xml.js
@@ -97,7 +97,4 @@ readDir(IN_DIR)
         })
         return promises
     })
-    .then(promises =>
-        Promise.all(promises)
-            .catch(e => console.error(e))
-    )
+    .then(promises => Promise.all(promises).catch(e => console.error(e)))

--- a/src/tiler/src/util/fs-promise.js
+++ b/src/tiler/src/util/fs-promise.js
@@ -14,5 +14,15 @@ export const readFile = (path, encoding) => new Promise((resolve, reject) => {
 export const writeFile = (path, data, encoding) => new Promise((resolve, reject) => {
     fs.writeFile(path, data, encoding, (err) => {
         if (err) reject(err)
+        // Real fs writeFile doesn't resolve to anything, but not
+        // resolving was breaking my promise chains
+        else resolve(path)
+    })
+})
+
+export const readDir = directory => new Promise((resolve, reject) => {
+    fs.readdir(directory, (err, files) => {
+        if (err) reject(err)
+        else resolve(files)
     })
 })


### PR DESCRIPTION
## Overview
This PR is in two small parts:
1. The [`build-xml`](src/tiler/src/util/build-xml.js) utility script has been modified to automatically transpile all `.mml` files in the `src/tiler/src/config` directory. The script now takes input and output directories, rather than in/out files, which are set to `src/tiler/src/config` and `src/tiler/bin/config` in the build step.
2. The query string `config` can now be optionally set to the name of a configuration file (without the file extension) in order to dynamically load any `.xml` files in `src/tiler/bin/config`. It defaults to "map-config".


### Demo
`http://localhost:3000/tile/13/2385/3103.png?config=data-type-example`
![image](https://user-images.githubusercontent.com/16990679/43530707-37937bcc-957c-11e8-89fa-5b9e3de03724.png)
`http://localhost:3000/tile/13/2385/3103.png?config=point-example`
![image](https://user-images.githubusercontent.com/16990679/43530727-47237254-957c-11e8-84cb-924ad1dfcb49.png)

## Testing Instructions

 * Spin up the development server with `./scripts/update` and `./scripts/server`.
 * Visit http://localhost:3000/tile/13/2385/3103.png. The server will default to using [`src/config/map-config.mml`](src/tiler/src/config/map-config.mml)'s configuration.
 * There are two other included configuration files, [`data-type-example.mml`](src/tiler/src/config/data-type-example.mml) and [`point-example.mml`](src/tiler/src/config/point-example.mml). Add those file names to http://localhost:3000/tile/13/2385/3103.png?config= to see what happens.


Resolves #80 

