### PR TITLE
Feature/refactor function signatures

### DIFF
--- a/src/tiler/src/api.js
+++ b/src/tiler/src/api.js
@@ -4,7 +4,7 @@
 
 import APIBuilder from 'claudia-api-builder'
 
-import { image, grid, vectorTile, createMap } from './tiler'
+import { imageTile, utfGrid, vectorTile, createMap } from './tiler'
 import HTTPError from './util/error-builder'
 
 const IMAGE_HEADERS = {
@@ -93,7 +93,7 @@ api.get(
             const layers = processLayers(req)
             const configOptions = processConfig(req)
 
-            return image(createMap(z, x, y, layers, configOptions))
+            return imageTile(createMap(z, x, y, layers, configOptions))
                 .then(img => new APIBuilder.ApiResponse(img, IMAGE_HEADERS, 200))
                 .catch(handleError)
         } catch (e) {
@@ -114,7 +114,7 @@ api.get(
             const layers = processLayers(req)
             const configOptions = processConfig(req)
 
-            return grid(createMap(z, x, y, layers, configOptions), utfFields)
+            return utfGrid(createMap(z, x, y, layers, configOptions), utfFields)
                 .then(g => new APIBuilder.ApiResponse(g, UTF_HEADERS, 200))
                 .catch(handleError)
         } catch (e) {

--- a/src/tiler/src/api.js
+++ b/src/tiler/src/api.js
@@ -4,7 +4,7 @@
 
 import APIBuilder from 'claudia-api-builder'
 
-import { image, grid, vectorTile } from './tiler'
+import { image, grid, vectorTile, createMap } from './tiler'
 import HTTPError from './util/error-builder'
 
 const IMAGE_HEADERS = {
@@ -93,7 +93,7 @@ api.get(
             const layers = processLayers(req)
             const configOptions = processConfig(req)
 
-            return image(z, x, y, layers, configOptions)
+            return image(createMap(z, x, y, layers, configOptions))
                 .then(img => new APIBuilder.ApiResponse(img, IMAGE_HEADERS, 200))
                 .catch(handleError)
         } catch (e) {
@@ -114,7 +114,7 @@ api.get(
             const layers = processLayers(req)
             const configOptions = processConfig(req)
 
-            return grid(z, x, y, utfFields, layers, configOptions)
+            return grid(createMap(z, x, y, layers, configOptions), utfFields)
                 .then(g => new APIBuilder.ApiResponse(g, UTF_HEADERS, 200))
                 .catch(handleError)
         } catch (e) {
@@ -142,7 +142,7 @@ api.get(
             const layers = processLayers(req)
             const configOptions = processConfig(req)
 
-            return vectorTile(z, x, y, layers, configOptions)
+            return vectorTile(createMap(z, x, y, layers, configOptions), z, x, y)
                 .then(vector => new APIBuilder.ApiResponse(vector, VECTOR_HEADERS, 200))
                 .catch(handleError)
         } catch (e) {

--- a/src/tiler/src/tiler.js
+++ b/src/tiler/src/tiler.js
@@ -96,7 +96,7 @@ export const createMap = (z, x, y, layers, configOptions) => {
  * @param y
  * @returns {Promise<any>}
  */
-export const image = (map) => {
+export const imageTile = (map) => {
     // create mapnik image
     const img = new mapnik.Image(TILE_WIDTH, TILE_HEIGHT)
 
@@ -125,12 +125,12 @@ export const image = (map) => {
  * @param y
  * @returns {Promise<any>}
  */
-export const grid = (map, utfFields) => {
-    const grd = new mapnik.Grid(TILE_WIDTH, TILE_HEIGHT)
+export const utfGrid = (map, utfFields) => {
+    const grid = new mapnik.Grid(TILE_WIDTH, TILE_HEIGHT)
 
     return map
         .then(m => new Promise((resolve, reject) => {
-            m.render(grd, {
+            m.render(grid, {
                 layer: 0,
                 fields: utfFields,
             }, (err, rendered) => {

--- a/src/tiler/src/tiler.js
+++ b/src/tiler/src/tiler.js
@@ -66,7 +66,7 @@ const fetchMapFile = (options) => {
  * @param y
  * @returns {Promise<mapnik.Map>}
  */
-const createMap = (z, x, y, layers, configOptions) => {
+export const createMap = (z, x, y, layers, configOptions) => {
     // Create a webmercator map with specified bounds
     const map = new mapnik.Map(TILE_WIDTH, TILE_HEIGHT)
     map.bufferSize = 64
@@ -104,15 +104,15 @@ const encodeAsPNG = renderedTile => new Promise((resolve, reject) => {
  * @param y
  * @returns {Promise<any>}
  */
-export const image = (z, x, y, layers, configOptions) => {
+export const image = (map) => {
     // create mapnik image
     const img = new mapnik.Image(TILE_WIDTH, TILE_HEIGHT)
 
     // render map to image
     // return asynchronous rendering method as a promise
-    return createMap(z, x, y, layers, configOptions)
-        .then(map => new Promise((resolve, reject) => {
-            map.render(img, {}, (err, result) => {
+    return map
+        .then(m => new Promise((resolve, reject) => {
+            m.render(img, {}, (err, result) => {
                 if (err) reject(err)
                 else resolve(result)
             })
@@ -128,12 +128,12 @@ export const image = (z, x, y, layers, configOptions) => {
  * @param y
  * @returns {Promise<any>}
  */
-export const grid = (z, x, y, utfFields, layers, configOptions) => {
+export const grid = (map, utfFields) => {
     const grd = new mapnik.Grid(TILE_WIDTH, TILE_HEIGHT)
 
-    return createMap(z, x, y, layers, configOptions)
-        .then(map => new Promise((resolve, reject) => {
-            map.render(grd, {
+    return map
+        .then(m => new Promise((resolve, reject) => {
+            m.render(grd, {
                 layer: 0,
                 fields: utfFields,
             }, (err, rendered) => {
@@ -161,12 +161,12 @@ export const grid = (z, x, y, utfFields, layers, configOptions) => {
  * @param layers
  * @returns {Promise<mapnik.Buffer>}
  */
-export const vectorTile = (z, x, y, layers, configOptions) => {
+export const vectorTile = (map, z, x, y) => {
     const vt = new mapnik.VectorTile(z, x, y)
 
-    return createMap(z, x, y, layers, configOptions)
-        .then(map => new Promise((resolve, reject) => {
-            map.render(vt, (err, tile) => {
+    return map
+        .then(m => new Promise((resolve, reject) => {
+            m.render(vt, (err, tile) => {
                 if (err) reject(err)
                 else resolve(tile)
             })

--- a/src/tiler/src/tiler.js
+++ b/src/tiler/src/tiler.js
@@ -89,14 +89,6 @@ export const createMap = (z, x, y, layers, configOptions) => {
         .catch(postgisFilter)
 }
 
-const encodeAsPNG = renderedTile => new Promise((resolve, reject) => {
-    renderedTile.encode('png', {}, (err, result) => {
-        if (err) reject(err)
-        else resolve(result)
-    })
-})
-
-
 /**
  * Returns a promise that renders a map tile for a given map coordinate
  * @param z
@@ -117,7 +109,12 @@ export const image = (map) => {
                 else resolve(result)
             })
         }))
-        .then(encodeAsPNG)
+        .then(renderedTile => new Promise((resolve, reject) => {
+            renderedTile.encode('png', {}, (err, result) => {
+                if (err) reject(err)
+                else resolve(result)
+            })
+        }))
         .catch(postgisFilter)
 }
 


### PR DESCRIPTION
## Overview

Because `image()`, `grid()`, and `vectorTile()` all share the same functional structure of 
1. Create a mapnik Map
2. Render the Map to the intended data format
3. Encode that data format to a form that can be transferred over the internet

I thought it made sense to refactor them such that the code format is consistent between functions. The main thing this PR does is change the function signatures in question to now accept a Promise<Map> + whatever other info the function may need to operate, rather than pass around 4+ variables that only get used by `createMap()`. I've also removed the promise-creating function that only `image()` used for encoding, and renamed the functions to share the same sort of naming scheme.

No actual functionality has been changed, I just thought it might be nice to streamline things a bit.

Resolves #86 

