### PR TITLE
Ensure arguments get passed to the right utilities in the right order

### DIFF
--- a/src/tiler/package.json
+++ b/src/tiler/package.json
@@ -29,7 +29,7 @@
     "destroy": "claudia destroy",
     "dev": "nodemon -e js,mss,json,mml,mss --ignore bin/ --exec yarn local",
     "lint": "eslint src",
-    "local": "yarn transpile && node --inspect=0.0.0.0:9229 node_modules/claudia-local-api/bin/claudia-local-api --abbrev 300 --api-module bin/api | bunyan -o short",
+    "local": "yarn transpile && node --inspect=0.0.0.0:9229 -- node_modules/claudia-local-api/bin/claudia-local-api --abbrev 300 --api-module bin/api | bunyan -o short",
     "parse-id": "jq -r '.api.id' claudia.json > .api-id",
     "test": "eslint src && jest --coverage",
     "transpile": "yarn build-xml && babel src -d bin --source-maps inline"


### PR DESCRIPTION
## Overview

On some machines the `--abbrev 300` argument in the `local` yarn script would get passed to node instead of to claudia-local-api. Added a `--` to make sure that the order of operations would be forced to work out.