### PR TITLE
Feature/demo performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ A deployed instance of Tilegarden consists of several AWS resources:
 
 #### Additional Configuration Options
  * `USER`: Left unspecified so that the code knows who the local user is from inside docker containers. Gets tacked on to the end of the project name at deployment.
- * `LAMBDA_TIMEOUT`: Time (in seconds) before your lambda function times out (maximum 300).
- * `LAMBDA_MEMORY`: Amount of memory (in MB) to allocate per function. Must be a multiple of 64, minimum 128, maximum 3008.
+ * `LAMBDA_TIMEOUT`: Time (in seconds) before your lambda function is automatically cancelled (maximum 300). You'll probably need to modify this value as tile rendering can take longer than AWS's default timeout, depending on the complexity of the data you're rendering.
+ * `LAMBDA_MEMORY`: Amount of memory (in MB) to allocate per function. Must be a multiple of 64, minimum 128, maximum 3008. As with `LAMBDA_TIMEOUT`, more complex data requires more allocated memory, but 128MB should be enough in most scenarios.
 
 #### Required AWS Permissions
 The AWS profile used for deployment must have at least the following policies and permissions:

--- a/demo/raster.html
+++ b/demo/raster.html
@@ -18,7 +18,8 @@
         document.addEventListener('DOMContentLoaded', function pageLoaded() {
             var map = L.map('map', {
                 center: [39.96,-75.15,],
-                zoom: 13,
+                zoom: 15,
+                minZoom: 13,
             });
 
             // add basemap

--- a/demo/utf-grid.html
+++ b/demo/utf-grid.html
@@ -18,7 +18,8 @@
 
         document.addEventListener('DOMContentLoaded', function pageLoaded() {
             var map = L.map('map', {
-                center: [39.96, -75.15], zoom: 12
+                center: [39.96, -75.15],
+                zoom: 15,
             });
 
             // add basemap

--- a/demo/vector.html
+++ b/demo/vector.html
@@ -27,9 +27,9 @@
             // list of layers
             var layers = {
                 'pwd_parcels': {
-                    id: 'tilegarden',
+                    id: 'pwd_parcels',
                     type: 'fill',
-                    source: 'tilegarden',
+                    source: 'pwd_parcels',
                     'source-layer': 'pwd_parcels',
                     paint: {
                         'fill-color': 'orange',
@@ -37,9 +37,9 @@
                     }
                 },
                 'street_centerline': {
-                    id: 'tilegarden',
+                    id: 'street_centerline',
                     type: 'line',
-                    source: 'tilegarden',
+                    source: 'street_centerline',
                     'source-layer': 'street_centerline',
                     paint: {
                         'line-color': 'red',
@@ -47,9 +47,9 @@
                     }
                 },
                 'inlets': {
-                    id: 'tilegarden',
+                    id: 'inlets',
                     type: 'circle',
-                    source: 'tilegarden',
+                    source: 'inlets',
                     'source-layer': 'inlets',
                     paint: {
                         'circle-color': 'orange',
@@ -69,16 +69,33 @@
 
             map.on('load', function mapLoaded() {
                 map.addSource(
-                    'tilegarden',
+                    'inlets',
                     {
                         type: 'vector',
-                        tiles: [TILESERVER_PATH+'vector/{z}/{x}/{y}?config=data-type-example']
+                        tiles: [TILESERVER_PATH+'vector/{z}/{x}/{y}?config=data-type-example&layers=inlets']
                     },
                 )
+
+                map.addSource(
+                    'street_centerline',
+                    {
+                        type: 'vector',
+                        tiles: [TILESERVER_PATH+'vector/{z}/{x}/{y}?config=data-type-example&layers=street_centerline']
+                    },
+                )
+
+                map.addSource(
+                    'pwd_parcels',
+                    {
+                        type: 'vector',
+                        tiles: [TILESERVER_PATH+'vector/{z}/{x}/{y}?config=data-type-example&layers=pwd_parcels']
+                    },
+                )
+
                 map.addLayer(layers['inlets'])
                 document.getElementById('stylebox').value = JSON.stringify(layers['inlets'].paint)
                 document.getElementById('dataDesc').innerHTML = LAYER_DESCS['inlets'];
-            })
+            });
 
             var LAYER_DESCS = {
                 'inlets': 'This point layer contains all the wastewater and stormwater inlets in Philadelphia with latitude and longitude coordinates. | <a href="https://www.opendataphilly.org/dataset/water-inlets">City of Philadelphia</a>',
@@ -86,11 +103,13 @@
                 'pwd_parcels': 'PWD stormwater billing parcels. The primary purpose of PWD_PARCEL layer is to calculate parcel-based stormwater charges for PWD customers under the new parcel-based stormwater billing program. | <a href="https://www.opendataphilly.org/dataset/pwd-stormwater-billing-parcels">City of Philadelphia</a>',
             }
 
+            var currentLayer = 'inlets';
             document.getElementById("selector").addEventListener('change', function selectorChange (e) {
                 var selection = document.getElementById("selector").value;
                 console.log(JSON.stringify(selection));
-                map.removeLayer('tilegarden');
-                map.addLayer(layers[selection]);
+                map.removeLayer(currentLayer);
+                currentLayer = selection;
+                map.addLayer(layers[currentLayer]);
                 document.getElementById('stylebox').value = JSON.stringify(layers[selection].paint);
                 document.getElementById('dataDesc').innerHTML = LAYER_DESCS[selection];
             });
@@ -100,7 +119,7 @@
                 var newStyle = JSON.parse(document.getElementById('stylebox').value);
                 for (var p in newStyle) {
                     if (newStyle.hasOwnProperty(p)) {
-                        map.setPaintProperty('tilegarden', p, newStyle[p]);
+                        map.setPaintProperty(currentLayer, p, newStyle[p]);
                     }
                 }
             });

--- a/demo/vector.html
+++ b/demo/vector.html
@@ -21,7 +21,8 @@
                 container: 'map',
                 style: 'mapbox://styles/mapbox/light-v9',
                 center: [ -75.15, 39.96,],
-                zoom: 13,
+                zoom: 15,
+                minZoom: 14,
             });
 
             // list of layers

--- a/env-template
+++ b/env-template
@@ -19,9 +19,11 @@ LAMBDA_REGION=us-east-1
 # name of role associated with this lambda function
 #LAMBDA_ROLE=role-name
 # Amount of time in seconds your lambdas will wait before timing out
-#LAMBDA_TIMEOUT=5
+# Increase this value if your tile requests are timing out
+#LAMBDA_TIMEOUT=15
 # Memory in MB allocated to your lambda functions
-#LAMBDA_MEMORY=3008
+# Increase this value if you plan on rendering vector tiles
+#LAMBDA_MEMORY=128
 # The following VPC (Virtual Private Cloud) settings should be used if you
 # need your lambdas to be able to connect to other AWS resources,
 # e.g. an RDS instance, and should match the subnets/security groups used

--- a/src/terraform/cloudfront.tf
+++ b/src/terraform/cloudfront.tf
@@ -30,7 +30,7 @@ resource "aws_cloudfront_distribution" "tilegarden_test" {
   }
 
 
-
+  price_class = "PriceClass_100"
   enabled = true
   is_ipv6_enabled = true
   comment = "Proxy for ${var.source_name}"


### PR DESCRIPTION
## Overview
This PR makes some changes to improve setup speed in the demo, just to make the whole thing run more seamlessly for demonstration. Specifically it:
 * Updates the defaults in `env-template` to give a better idea of what performance requirements are normal.
 * Speed up CloudFront deployment time by using the lowest breadth price class by default.
 * Modify vector tile demo to request one layer at a time, for smaller individual tile sizes.
 * Increase zoom level on all demos for performance reasons.


### Notes
A TBD aspect of this pull request is updating the timeout/memory settings in the `.env` on the GitHub pages branch. I'm going to wait on doing that, though, until after the talks, because I very much do not want to break/spend time fixing the demo branch right now.


## Testing Instructions

 * Spin up a development server with `./scripts/update`/`./scripts/server`
 * Check out the updated demo pages, which should load faster overall.

