### PR TITLE
Feature/streamline deployment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,17 +3,19 @@
 USER
 AWS_PROFILE
 # $USER will be appended to the project name specified here
-PROJECT_NAME=tilegarden-dev
+PROJECT_NAME=
 
-# Enter your database credentials here:
-PROD_TILEGARDEN_DB=
-PROD_TILEGARDEN_HOST=
-PROD_TILEGARDEN_PASSWORD=
-PROD_TILEGARDEN_USER=
+# Example production credentials
+# These get templated in to your map-config.mml file
+# when configuration files are built.
+#PROD_TILEGARDEN_DB=
+#PROD_TILEGARDEN_HOST=
+#PROD_TILEGARDEN_PASSWORD=
+#PROD_TILEGARDEN_USER=
 
 # Function config information
 ## REQUIRED ##
-LAMBDA_REGION=us-east-1
+LAMBDA_REGION=
 
 ## OPTIONAL ##
 # name of role associated with this lambda function

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Dependencies: docker, docker-compose
  * Configure your map:
    * Open the file [`src/tiler/src/config/map-config.mml`](src/tiler/src/config/map-config.mml). This is where you specify your map settings. [A full specification for Carto's .mml format can be found here.](https://cartocss.readthedocs.io/en/latest/mml.html)
    * Of particular note is the “Layer” property, which specifies the layers of your map (as an array). Odds are you won't have to change the target srs (at the top of the file), but make sure that the srs of each layer is specified properly. By default, all layers of your map are displayed at once, but different combinations of layers can be selected using the `layers` query string. See [Filters](#filters) for more info.
- * Create a copy of [`env-template`](env-template) named `.env`. This contains production-specific configuration options and doesn't need to be filled out right now (but must exist in order to run the development server).
+ * Create a copy of [`env-template`](.env.template) named `.env`. This contains production-specific configuration options and doesn't need to be filled out right now (but must exist in order to run the development server).
  * Run `./scripts/update` to create your Docker containers and populate the development database. The optional flag `--download` will download the data sets used for our demos.
  * Run `./scripts/server` to start the development server. It will be available at [localhost:3000](http://localhost:3000/), your tiles can be found at `/tile/{z}/{x}/{y}.png`.
  * The local development server exposes a node.js debugger, which can be attached to by Chrome DevTools or your IDE of choice [(see below)](#Debugging).

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -e
+
+deploy_new=""
+no_cache=""
+
+function usage() {
+    echo -n "Usage: $(basename "${0}") [OPTION]
+Deploys a Tilegarden instance to AWS by building docker containers first
+Options:
+    --help        Show usage
+    --new        Deploy as a new lambda
+    --no-cache    Don't use cache when building containers
+"
+    exit 0
+}
+
+function main() {
+	if [[ $deploy_new != "--new" && ! -f /src/tiler/claudia.json ]]; then
+		echo "No existing deployment found to update! (did you mean to use '--new'?)"
+		exit 1
+	fi
+
+    docker-compose build terraform
+
+	if [ "${no_cache}" == "--no-cache" ]; then
+    	docker-compose build --no-cache tiler
+    else
+    	docker-compose build tiler
+    fi
+
+	# Capture output to check for specific error
+	./scripts/publish "${deploy_new}"
+}
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    # handle command line arguments
+    # modified from https://stackoverflow.com/a/7069755
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -n| --new)
+                deploy_new='--new'
+                shift
+                ;;
+            --no-cache)
+                no_cache='--no-cache'
+                shift
+                ;;
+            -h| --help| *)
+                usage
+                ;;
+        esac
+    done
+
+    main
+fi
+

--- a/scripts/publish
+++ b/scripts/publish
@@ -4,7 +4,7 @@ set -e
 
 function usage() {
     echo -n "Usage: $(basename "${0}") [OPTION]
-Publish lambdas to AWS Lambda
+Publish project in development to AWS Lambda
 Options:
     --new     Deploy as a new lambda
     --help      Display this help text


### PR DESCRIPTION
## Overview
This PR aims to streamline deployment by
1. giving `env-template` a name that better indicates what you're meant to do with it.
2. creating a `deploy` script that basically just calls `docker-compose build` before `./scripts/publish`

The state of this PR is sort of temporary as we work out what all should be included in it vs. #106 

## Testing Instructions

 * Run `./scripts/clean` on your development environment (or just make a fresh clone if you don't have the project on your machine)
 * Set up your project for deployment without running the docker containers, and then run `./scripts/deploy --new`. It should work where `./scripts/publish` wouldn't as it builds containers as well as publishing.


Resolves #46 

