### PR TITLE
Use pre-installed AWS SDK on Lambda

### DIFF
--- a/scripts/clean
+++ b/scripts/clean
@@ -11,7 +11,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         # Remove build artifacts from local machine
-        docker-compose run tiler rm -rf bin/ node_modules/
+        docker-compose run --no-deps tiler rm -rf bin/ node_modules/
 
         # Stop containers and shut down the network
         docker-compose down --volumes

--- a/scripts/destroy
+++ b/scripts/destroy
@@ -22,11 +22,11 @@ function main() {
         # If any part of this fails, the parts that didn't fail
         # remain destroyed, so it's best to just carry on and
         # follow through.
-        docker-compose run tiler yarn destroy || true
+        docker-compose run --no-deps tiler yarn destroy || true
         docker-compose run -e TF_VAR_source_id=$(<src/tiler/.api-id) terraform destroy -auto-approve
 
         # Remove local config files
-        docker-compose run tiler rm claudia.json .api-id
+        docker-compose run --no-deps tiler rm claudia.json .api-id
         docker-compose run --entrypoint rm terraform -rf .terraform terraform.tfstate terraform.tfstate.backup
 
     else

--- a/scripts/publish
+++ b/scripts/publish
@@ -14,9 +14,9 @@ Options:
 function main() {
     if [ "${1}" = "--new" ]
     then
-        docker-compose run --rm -e NODE_ENV=production tiler yarn deploy-new
+        docker-compose run --rm --no-deps -e NODE_ENV=production tiler yarn deploy-new
     else
-        docker-compose run --rm -e NODE_ENV=production tiler yarn deploy
+        docker-compose run --rm --no-deps -e NODE_ENV=production tiler yarn deploy
     fi
 
 	# Deploy CloudFront proxy

--- a/scripts/test
+++ b/scripts/test
@@ -16,7 +16,7 @@ then
     then
         usage
     else
-        docker-compose run tiler yarn test
+        docker-compose run --no-deps tiler yarn test
     fi
     exit
 fi

--- a/scripts/update
+++ b/scripts/update
@@ -15,9 +15,7 @@ then
         usage
     else
         # Build containers.
-        docker-compose \
-            -f docker-compose.yml \
-            build
+        docker-compose build
 
         # Download sample data if flag is set
         if [ "${1:-}" = "--download" ]

--- a/src/tiler/.eslintrc.json
+++ b/src/tiler/.eslintrc.json
@@ -12,6 +12,7 @@
     "camelcase": 2,
     "vars-on-top": 2,
     "strict": 2,
-    "max-statements": ["error", 50]
+    "max-statements": ["error", 50],
+    "import/no-extraneous-dependencies": ["error", {"optionalDependencies": true}]
   }
 }

--- a/src/tiler/package.json
+++ b/src/tiler/package.json
@@ -24,8 +24,8 @@
   ],
   "scripts": {
     "build-all-xml": "./scripts/build-all-xml.sh src/config bin/config",
-    "deploy": "yarn transpile && claudia update ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}}",
-    "deploy-new": "yarn transpile && claudia create --api-module bin/api --name ${PROJECT_NAME} --region ${LAMBDA_REGION} ${LAMBDA_ROLE:+--role ${LAMBDA_ROLE}} ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}} && yarn parse-id",
+    "deploy": "yarn transpile && claudia update --no-optional-dependencies ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}}",
+    "deploy-new": "yarn transpile && claudia create --no-optional-dependencies --api-module bin/api --name ${PROJECT_NAME} --region ${LAMBDA_REGION} ${LAMBDA_ROLE:+--role ${LAMBDA_ROLE}} ${LAMBDA_TIMEOUT:+--timeout ${LAMBDA_TIMEOUT}} ${LAMBDA_MEMORY:+--memory ${LAMBDA_MEMORY}} ${LAMBDA_SECURITY_GROUPS:+--security-group-ids ${LAMBDA_SECURITY_GROUPS}} ${LAMBDA_SUBNETS:+--subnet-ids ${LAMBDA_SUBNETS}} && yarn parse-id",
     "destroy": "claudia destroy",
     "dev": "nodemon -e js,mss,json,mml,mss --ignore bin/ --ignore '*.temp.mml' --exec yarn local",
     "lint": "eslint src",
@@ -49,11 +49,13 @@
     "rewire": "^4.0.1"
   },
   "dependencies": {
-    "aws-sdk": "^2.284.1",
     "babel-runtime": "6",
     "claudia-api-builder": "^4.1.0",
     "mapnik": "^3.7.2",
     "sql-escape-string": "^1.1.0",
     "xml2js": "^0.4.19"
+  },
+  "optionalDependencies": {
+    "aws-sdk": "^2.290.0"
   }
 }


### PR DESCRIPTION
## Overview

The Lambda environment comes with the AWS SDK pre-installed, so it wastes space in the bundle to install it ourselves.

Also bumps the version listed in package.json (and installed in development) to the [current version pre-installed on Lambda](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html)

### Notes
    
- Per [this issue](https://github.com/claudiajs/claudia/issues/82), just moving it to `devDependencies` won't work because Claudia validates the bundle and it's an error for the package to be missing, but that can be worked around by making at an optional dependency and telling Claudia not to install optional.
- This also adds a `--no-deps` argument to a few of the `docker-compose` commands in places where the `tiler` container is being used but the `database` container (on which it depends via the `links:` parameter) isn't needed.

## Testing Instructions

- To test local development, delete `node_modules` or run `scripts/clean` to clear the existing installation, then run `scripts/update` to build the tiler container again.  It should still install `aws-sdk` and work normally.
- To test the deployed package, run `scripts/publish` or `scripts/publish --new`.  Export the Lambda function to a zip file and confirm that `aws-sdk` is not present in the `node_modules` directory.
- If you already had a Lambda function deployed, you should be able to export the previous version and confirm that the size of the bundle has decreased.

Resolves #118.