### PR TITLE
Add index to geom columns of imported tables

### DIFF
--- a/scripts/load_sample_data
+++ b/scripts/load_sample_data
@@ -120,18 +120,27 @@ function load() {
     fi
 }
 
+function add_index {
+    table=${1}
+    column="geom"
+    ${PSQL} -c "CREATE INDEX IF NOT EXISTS ${table}_${column}_idx \
+                ON ${table} USING GIST (${column})"
+}
+
 function add_table() {
-    if table_exists "${2}"; then
+    filename=${1}
+    table=${2}
+    if table_exists "${table}"; then
         if [ "$force_reload" = true ]; then
-            drop ${tablename}
-            load "${1}" "${2}"
+            drop "${table}"
         else
-            echo "table ${2} exists"
+            echo "table ${table} exists"
+            return
         fi
-    else
-        echo "Loading ${2}"
-        load "${1}" "${2}"
     fi
+    echo "Loading ${table}"
+    load "${filename}" "${table}"
+    add_index "${table}"
 }
 
 


### PR DESCRIPTION
## Overview

Adds a step to the sample data importer to index the geometry columns.

### Notes

- I didn't really investigate whether query speed is a bottleneck right now, so I don't know if this makes a measurable difference in overall performance.  It seems like a no-brainer, so trying to answer that question doesn't seem worth the trouble.
- I created the indexes by hand on our test RDS instance.
- This came up in discussion around issue #64, but there's no issue open for this particular change.

## Testing Instructions

- If you don't already have a database container, bringing one up (with `scripts/update --download`) will import the tables and add the indexes.
- If you already have a database container with the data loaded, run `docker-compose exec database bash -c "./load_sample_data -f"` to reload the data.
- Run `scripts/console database` and inspect the tables to see that they now have indexes on the `geom` column.
