### PR TITLE
Remove babel-runtime

### DIFF
--- a/src/tiler/package.json
+++ b/src/tiler/package.json
@@ -49,7 +49,6 @@
     "rewire": "^4.0.1"
   },
   "dependencies": {
-    "babel-runtime": "6",
     "claudia-api-builder": "^4.1.0",
     "mapnik": "^3.7.2",
     "sql-escape-string": "^1.1.0",


### PR DESCRIPTION
Per issue #115, we're not sure what babel-runtime was added for. As far as I can tell, we don't need it.

Resolves #115.