### PR TITLE
Convert to async/await

### DIFF
--- a/src/tiler/.eslintrc.json
+++ b/src/tiler/.eslintrc.json
@@ -11,6 +11,7 @@
     "no-unexpected-multiline": 2,
     "max-len": ["error", 100, { "ignoreComments": true}],
     "max-statements": ["error", 50],
+    "object-curly-newline": ["error", { "consistent": true }],
     "quotes": ["error", "single"],
     "semi": [2, "never"],
     "strict": 2,

--- a/src/tiler/src/api.js
+++ b/src/tiler/src/api.js
@@ -4,12 +4,7 @@
 
 const APIBuilder = require('claudia-api-builder')
 
-const {
-    imageTile,
-    utfGrid,
-    vectorTile,
-    createMap,
-} = require('./tiler')
+const { imageTile, utfGrid, vectorTile } = require('./tiler')
 const HTTPError = require('./util/error-builder')
 
 const IMAGE_HEADERS = {
@@ -97,8 +92,9 @@ api.get(
             const { z, x, y } = processCoords(req)
             const layers = processLayers(req)
             const configOptions = processConfig(req)
+            const mapConfig = { z, x, y, layers, configOptions }
 
-            return imageTile(createMap(z, x, y, layers, configOptions))
+            return imageTile(mapConfig)
                 .then(img => new APIBuilder.ApiResponse(img, IMAGE_HEADERS, 200))
                 .catch(handleError)
         } catch (e) {
@@ -118,8 +114,9 @@ api.get(
             const utfFields = processUTFQuery(req)
             const layers = processLayers(req)
             const configOptions = processConfig(req)
+            const mapConfig = { z, x, y, layers, configOptions }
 
-            return utfGrid(createMap(z, x, y, layers, configOptions), utfFields)
+            return utfGrid(mapConfig, utfFields)
                 .then(g => new APIBuilder.ApiResponse(g, UTF_HEADERS, 200))
                 .catch(handleError)
         } catch (e) {
@@ -146,8 +143,9 @@ api.get(
             const { z, x, y } = processCoords(req)
             const layers = processLayers(req)
             const configOptions = processConfig(req)
+            const mapConfig = { z, x, y, layers, configOptions }
 
-            return vectorTile(createMap(z, x, y, layers, configOptions), z, x, y)
+            return vectorTile(mapConfig)
                 .then(vector => new APIBuilder.ApiResponse(vector, VECTOR_HEADERS, 200))
                 .catch(handleError)
         } catch (e) {

--- a/src/tiler/src/tiler.js
+++ b/src/tiler/src/tiler.js
@@ -22,22 +22,34 @@ const DEFAULT_CONFIG_FILENAME = 'map-config.xml'
 // Register plugins
 mapnik.register_default_input_plugins()
 
+/* Utility function to correctly promisify object methods
+ *
+ * Many methods use 'this' in a way that makes them break when you try to use util.promisify
+ * on them. There's a workaround, though (see https://github.com/ljharb/util.promisify/issues/12)
+ * This is a convenience function that implements it.
+ * The resulting syntax, `promisifyMethod(object, 'method')` is a bit weird, but still seems better
+ * than having to do object.method.bind(object) everywhere.
+ */
+function promisifyMethod(object, method) {
+    return promisify(object[method].bind(object))
+}
+
 // If there's a problem with the database, the details of that shouldn't be exposed to the user.
 const postgisFilter = (e) => {
     console.error(e)
     if (e.toString().indexOf('Postgis Plugin') > -1) {
-        throw HTTPError('Postgis Error', 500)
+        return HTTPError('Postgis Error', 500)
     }
-    throw e
+    return e
 }
 
 /**
  * Based off the config options object, search for a config.xml
  * file and return it as a Promise that evaluates to an XML string.
  * @param options
- * @returns {Promise<any>}
+ * @returns {Promise<string>}
  */
-const fetchMapFile = (options) => {
+function fetchMapFile(options) {
     const { s3bucket, config = DEFAULT_CONFIG_FILENAME } = options
 
     // If an s3 bucket is specified, treat config as an object key and attempt to fetch
@@ -69,127 +81,75 @@ const fetchMapFile = (options) => {
 
 /**
  * Creates a map based on configured datasource and style information
- * @param z
- * @param x
- * @param y
- * @returns {Promise<mapnik.Map>}
  */
-const createMap = (mapConfig) => {
+async function createMap(mapConfig) {
     const { z, x, y, layers, configOptions } = mapConfig
     // Create a webmercator map with specified bounds
     const map = new mapnik.Map(TILE_WIDTH, TILE_HEIGHT)
     map.bufferSize = 64
 
-    // Load map specification from xml string
-    return fetchMapFile(configOptions)
-        .then(xml => filterVisibleLayers(xml, layers))
-        .then(xml => new Promise((resolve, reject) => {
-            map.fromString(xml, (err, result) => {
-                if (err) {
-                    reject(err)
-                } else {
-                    /* eslint-disable-next-line no-param-reassign */
-                    result.extent = bbox(z, x, y, TILE_HEIGHT, result.srs)
-
-                    resolve(result)
-                }
-            })
-        }))
-        .catch(postgisFilter)
+    // Load map specificationu from xml string
+    try {
+        const mapConfigXml = await fetchMapFile(configOptions)
+        const filteredMapConfigXml = await filterVisibleLayers(mapConfigXml, layers)
+        const configuredMap = await promisifyMethod(map, 'fromString')(filteredMapConfigXml)
+        configuredMap.extent = bbox(z, x, y, TILE_HEIGHT, configuredMap.srs)
+        return configuredMap
+    } catch (err) {
+        throw postgisFilter(err)
+    }
 }
 
 /**
- * Returns a promise that renders a map tile for a given map coordinate
- * @param z
- * @param x
- * @param y
- * @returns {Promise<any>}
+ * Renders a map tile for a given map coordinate
  */
-module.exports.imageTile = (mapConfig) => {
+module.exports.imageTile = async (mapConfig) => {
     // create mapnik image
     const img = new mapnik.Image(TILE_WIDTH, TILE_HEIGHT)
 
     // render map to image
-    // return asynchronous rendering method as a promise
-    const map = createMap(mapConfig)
-    return map
-        .then(m => new Promise((resolve, reject) => {
-            m.render(img, {}, (err, result) => {
-                if (err) reject(err)
-                else resolve(result)
-            })
-        }))
-        .then(renderedTile => new Promise((resolve, reject) => {
-            renderedTile.encode('png', {}, (err, result) => {
-                if (err) reject(err)
-                else resolve(result)
-            })
-        }))
-        .catch(postgisFilter)
+    try {
+        const map = await createMap(mapConfig)
+        const tile = await promisifyMethod(map, 'render')(img, {})
+        const encoded = await promisifyMethod(tile, 'encode')('png', {})
+        return encoded
+    } catch (err) {
+        throw postgisFilter(err)
+    }
 }
 
 /**
- * Return a promise that renders a utf grid for a given map coordinate
- * @param z
- * @param x
- * @param y
- * @returns {Promise<any>}
+ * Renders a utf grid for a given map coordinate
  */
-module.exports.utfGrid = (mapConfig, utfFields) => {
+module.exports.utfGrid = async (mapConfig, utfFields) => {
     const grid = new mapnik.Grid(TILE_WIDTH, TILE_HEIGHT)
-
-    const map = createMap(mapConfig)
-    return map
-        .then(m => new Promise((resolve, reject) => {
-            m.render(grid, {
-                layer: 0,
-                fields: utfFields,
-            }, (err, rendered) => {
-                if (err) reject(err)
-                else resolve(rendered)
-            })
-        }))
-        .then(g => new Promise((resolve, reject) => {
-            g.encode({
-                resolution: 4,
-            }, (err, result) => {
-                if (err) reject(err)
-                else resolve(result)
-            })
-        }))
-        .catch(postgisFilter)
+    const map = await createMap(mapConfig)
+    try {
+        const tile = await promisifyMethod(map, 'render')(grid, { layer: 0, fields: utfFields })
+        const encoded = await promisifyMethod(tile, 'encode')({ resolution: 4 })
+        return encoded
+    } catch (err) {
+        throw postgisFilter(err)
+    }
 }
 
 /**
- * Return a promise that resolves to a vector tile of the input
- * coordinates, compressed as a gzip
- * @param z
- * @param x
- * @param y
- * @param layers
- * @returns {Promise<mapnik.Buffer>}
+ * Renders a vector tile of the input coordinates, compressed as a gzip
  */
-module.exports.vectorTile = (mapConfig, z, x, y) => {
+module.exports.vectorTile = async (mapConfig, z, x, y) => {
     const vt = new mapnik.VectorTile(z, x, y)
 
-    const map = createMap(mapConfig)
-    return map
-        .then(m => new Promise((resolve, reject) => {
-            m.render(vt, (err, tile) => {
-                if (err) reject(err)
-                else resolve(tile)
-            })
-        }))
-        .then(tile => new Promise((resolve, reject) => {
-            const compressionOptions = {
-                compression: 'gzip',
-                level: 9,
-                strategy: 'FILTERED',
-            }
-            tile.getData(compressionOptions, (err, data) => {
-                if (err) reject(err)
-                else resolve(data)
-            })
-        }))
-        .catch(postgisFilter)
+    const map = await createMap(mapConfig)
+    try {
+        const tile = await promisifyMethod(map, 'render')(vt)
+        const compressionOptions = {
+            compression: 'gzip',
+            level: 9,
+            strategy: 'FILTERED',
+        }
+        const compressed = await promisifyMethod(tile, 'getData')(compressionOptions)
+        return compressed
+    } catch (err) {
+        throw postgisFilter(err)
+    }
 }

--- a/src/tiler/src/tiler.js
+++ b/src/tiler/src/tiler.js
@@ -135,7 +135,8 @@ module.exports.utfGrid = async (mapConfig, utfFields) => {
 /**
  * Renders a vector tile of the input coordinates, compressed as a gzip
  */
-module.exports.vectorTile = async (mapConfig, z, x, y) => {
+module.exports.vectorTile = async (mapConfig) => {
+    const { z, x, y } = mapConfig
     const vt = new mapnik.VectorTile(z, x, y)
 
     const map = await createMap(mapConfig)

--- a/src/tiler/src/tiler.js
+++ b/src/tiler/src/tiler.js
@@ -74,7 +74,8 @@ const fetchMapFile = (options) => {
  * @param y
  * @returns {Promise<mapnik.Map>}
  */
-module.exports.createMap = (z, x, y, layers, configOptions) => {
+const createMap = (mapConfig) => {
+    const { z, x, y, layers, configOptions } = mapConfig
     // Create a webmercator map with specified bounds
     const map = new mapnik.Map(TILE_WIDTH, TILE_HEIGHT)
     map.bufferSize = 64
@@ -104,12 +105,13 @@ module.exports.createMap = (z, x, y, layers, configOptions) => {
  * @param y
  * @returns {Promise<any>}
  */
-module.exports.imageTile = (map) => {
+module.exports.imageTile = (mapConfig) => {
     // create mapnik image
     const img = new mapnik.Image(TILE_WIDTH, TILE_HEIGHT)
 
     // render map to image
     // return asynchronous rendering method as a promise
+    const map = createMap(mapConfig)
     return map
         .then(m => new Promise((resolve, reject) => {
             m.render(img, {}, (err, result) => {
@@ -133,9 +135,10 @@ module.exports.imageTile = (map) => {
  * @param y
  * @returns {Promise<any>}
  */
-module.exports.utfGrid = (map, utfFields) => {
+module.exports.utfGrid = (mapConfig, utfFields) => {
     const grid = new mapnik.Grid(TILE_WIDTH, TILE_HEIGHT)
 
+    const map = createMap(mapConfig)
     return map
         .then(m => new Promise((resolve, reject) => {
             m.render(grid, {
@@ -166,9 +169,10 @@ module.exports.utfGrid = (map, utfFields) => {
  * @param layers
  * @returns {Promise<mapnik.Buffer>}
  */
-module.exports.vectorTile = (map, z, x, y) => {
+module.exports.vectorTile = (mapConfig, z, x, y) => {
     const vt = new mapnik.VectorTile(z, x, y)
 
+    const map = createMap(mapConfig)
     return map
         .then(m => new Promise((resolve, reject) => {
             m.render(vt, (err, tile) => {


### PR DESCRIPTION
## Overview

Converts all asynchronous handling from promises to async/await.  No functional changes.

### Notes
Most of the callback functions we were wrapping in promises are object method calls rather than stand-alone functions, and it turns out `util.promisify` doesn't always handle those correctly.  Apparently the `this` object doesn't necessarily match, so methods that use it will fail.  So this defines a convenience function, `promisifyMethod`, that works around that by explicitly calling `.bind(obj)`, per the advice [here](https://github.com/ljharb/util.promisify/issues/12).  It makes the syntax a bit weird (passing the method name as a string) but it seems nicer than having to put that `bind` workaround in every `promisify` call.

I revised the interface between the `api` functions and the `tiler` functions a bit.  We were importing `createMap` into `api.js` then calling it inline in the invocations of the tile rendering functions.  Now the calls from `api.js` just pass the map config parameters and `createMap` happens inside the rendering functions.  This doesn't really change what's happening, just where, but it seems simpler and made it easier to refactor `createMap` to an async function.  It also means the `vectorTile` function can now get the z,x,y parameters from the `mapConfig` rather than having a separate copy passed in.


