### PR TITLE
Modify map config as JS object

### DIFF
--- a/demo/client-filter.html
+++ b/demo/client-filter.html
@@ -21,9 +21,10 @@
             });
 
             // add basemap
-            var basemap = L.tileLayer('https://korona.geog.uni-heidelberg.de/tiles/roadsg/x={x}&y={y}&z={z}', {
-                maxZoom: 19,
-                attribution: 'Imagery from <a href="http://giscience.uni-hd.de/">GIScience Research Group @ University of Heidelberg</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+            var basemap = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+                subdomains: 'abcd',
+                maxZoom: 19
             });
             map.addLayer(basemap)
 

--- a/demo/layer-filter.html
+++ b/demo/layer-filter.html
@@ -21,9 +21,10 @@
             });
 
             // add basemap
-            var basemap = L.tileLayer('https://korona.geog.uni-heidelberg.de/tiles/roadsg/x={x}&y={y}&z={z}', {
-                maxZoom: 19,
-                attribution: 'Imagery from <a href="http://giscience.uni-hd.de/">GIScience Research Group @ University of Heidelberg</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+            var basemap = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+                subdomains: 'abcd',
+                maxZoom: 19
             });
             map.addLayer(basemap)
 

--- a/demo/raster.html
+++ b/demo/raster.html
@@ -23,9 +23,10 @@
             });
 
             // add basemap
-            var basemap = L.tileLayer('https://korona.geog.uni-heidelberg.de/tiles/roadsg/x={x}&y={y}&z={z}', {
-                maxZoom: 19,
-                attribution: 'Imagery from <a href="http://giscience.uni-hd.de/">GIScience Research Group @ University of Heidelberg</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+            var basemap = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+                subdomains: 'abcd',
+                maxZoom: 19
             });
             map.addLayer(basemap);
 

--- a/demo/utf-grid.html
+++ b/demo/utf-grid.html
@@ -23,9 +23,10 @@
             });
 
             // add basemap
-            var basemap = L.tileLayer('https://korona.geog.uni-heidelberg.de/tiles/roadsg/x={x}&y={y}&z={z}', {
-                maxZoom: 19,
-                attribution: 'Imagery from <a href="http://giscience.uni-hd.de/">GIScience Research Group @ University of Heidelberg</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+            var basemap = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+                subdomains: 'abcd',
+                maxZoom: 19
             });
             map.addLayer(basemap);
 

--- a/src/tiler/src/util/layer-filter.js
+++ b/src/tiler/src/util/layer-filter.js
@@ -1,12 +1,9 @@
 /**
- * Accepts a string of XML and filters it to produce a string of XML where all layers not in
- * the list of enabled layers have their "status" property set to false, excluding them
- * from rendering.
+ * Defines a function that accepts a config XML converted to an object and returns the same
+ * object with the "status" property set to false for all layers not in the list of enabled
+ * layers, excluding them from rendering.
  */
-
-const { promisify } = require('util')
 const sqlString = require('sql-escape-string')
-const xmlParser = require('xml2js')
 
 const HTTPError = require('./error-builder')
 
@@ -110,18 +107,11 @@ const filter = (xmlJson, enabledLayers) => {
     return xmlJson
 }
 
-// Convert json back to an xml string
-const returnToXml = (xmlJson) => {
-    const builder = new xmlParser.Builder()
-    return builder.buildObject(xmlJson)
-}
-
-module.exports = async (xmlString, enabledLayers) => {
+module.exports = async (xmlJsonObj, enabledLayers) => {
     // skip entire process if no layers are to be parsed
     if (!enabledLayers || enabledLayers.length < 1) {
-        return xmlString
+        return xmlJsonObj
     }
 
-    const xmlJson = await promisify(xmlParser.parseString)(xmlString)
-    return returnToXml(filter(xmlJson, enabledLayers))
+    return filter(xmlJsonObj, enabledLayers)
 }

--- a/src/tiler/src/util/xml-tools.js
+++ b/src/tiler/src/util/xml-tools.js
@@ -1,0 +1,25 @@
+/* Helper functions to encapsulate converting to and from XML.
+ *
+ * There's not much here, but it does get reused, and having it centralized should make it
+ * easier to change libraries or settings if necessary.
+ */
+
+const { promisify } = require('util')
+const xml2js = require('xml2js')
+
+// Make an async-friendly version of the parser
+const parsePromise = promisify(xml2js.parseString)
+
+async function parseXml(xmlString) {
+    return parsePromise(xmlString)
+}
+
+function buildXml(xmlJsObj) {
+    const builder = new xml2js.Builder()
+    return builder.buildObject(xmlJsObj)
+}
+
+module.exports = {
+    parseXml,
+    buildXml,
+}

--- a/src/tiler/tests/layer-filter.test.js
+++ b/src/tiler/tests/layer-filter.test.js
@@ -3,6 +3,7 @@ const rewire = require('rewire')
 const filterLayers = require('../src/util/layer-filter')
 const filterer = rewire('../src/util/layer-filter'),
     structureQuery = filterer.__get__('structureQuery')
+const { parseXml, buildXml } = require('../src/util/xml-tools')
 
 describe('structureQuery', () => {
     test('One value', () => {
@@ -156,7 +157,7 @@ describe('structureQuery', () => {
 })
 
 describe('filterLayers', () => {
-    test('Just a string name', () => {
+    test('Just a string name', async () => {
         const layers = ['PWD']
         expect.assertions(1)
 
@@ -175,11 +176,11 @@ describe('filterLayers', () => {
   <Layer name="STATE" status="false"/>
   <Layer name="AIRPRT" status="false"/>
 </Map>`
-
-        return expect(filterLayers(xml, layers)).resolves.toBe(expected)
+        const xmlJson = await parseXml(xml)
+        return expect(filterLayers(xmlJson, layers).then(buildXml)).resolves.toBe(expected)
     })
 
-    test('Several string names', () => {
+    test('Several string names', async () => {
         const layers = ['PWD', 'STATE']
         expect.assertions(1)
 
@@ -199,10 +200,11 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT" status="false"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).resolves.toBe(expected)
+        const xmlJson = await parseXml(xml)
+        return expect(filterLayers(xmlJson, layers).then(buildXml)).resolves.toBe(expected)
     })
 
-    test('Just an object name', () => {
+    test('Just an object name', async () => {
         const layers = [{name:'PWD'}]
         expect.assertions(1)
 
@@ -222,10 +224,11 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT" status="false"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).resolves.toBe(expected)
+        const xmlJson = await parseXml(xml)
+        return expect(filterLayers(xmlJson, layers).then(buildXml)).resolves.toBe(expected)
     })
 
-    test('Several object names', () => {
+    test('Several object names', async () => {
         const layers = [{name:'PWD'}, {name:'STATE'}]
         expect.assertions(1)
 
@@ -245,10 +248,11 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT" status="false"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).resolves.toBe(expected)
+        const xmlJson = await parseXml(xml)
+        return expect(filterLayers(xmlJson, layers).then(buildXml)).resolves.toBe(expected)
     })
 
-    test('Object name + 1 filter', () => {
+    test('Object name + 1 filter', async () => {
         const layers = [{name:'PWD', filters: [{col:'owner', val:'PWD'}]}]
         expect.assertions(1)
 
@@ -276,10 +280,11 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT" status="false"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).resolves.toBe(expected)
+        const xmlJson = await parseXml(xml)
+        return expect(filterLayers(xmlJson, layers).then(buildXml)).resolves.toBe(expected)
     })
 
-    test('Object name + 2 filters', () => {
+    test('Object name + 2 filters', async () => {
         const layers = [{name:'PWD', filters: [{col:'owner', val:'PWD'}, {col:'operator', val:'PWD'}]}]
         expect.assertions(1)
 
@@ -307,10 +312,11 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT" status="false"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).resolves.toBe(expected)
+        const xmlJson = await parseXml(xml)
+        return expect(filterLayers(xmlJson, layers).then(buildXml)).resolves.toBe(expected)
     })
 
-    test('dont filter if layer list is empty', () => {
+    test('dont filter if layer list is empty', async () => {
         const layers = []
         const xml =
 `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -320,10 +326,11 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT"/>
 </Map>`
         expect.assertions(1)
-        return expect(filterLayers(xml, layers)).resolves.toBe(xml)
+        const xmlJson = await parseXml(xml)
+        return expect(filterLayers(xmlJson, layers).then(buildXml)).resolves.toBe(xml)
     })
 
-    test('dont filter if there is no layer list', () => {
+    test('dont filter if there is no layer list', async () => {
         const xml =
 `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Map>
@@ -332,10 +339,11 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT"/>
 </Map>`
         expect.assertions(1)
-        return expect(filterLayers(xml)).resolves.toBe(xml)
+        const xmlJson = await parseXml(xml)
+        return expect(filterLayers(xmlJson).then(buildXml)).resolves.toBe(xml)
     })
 
-    test('Throw error if a layer doesn\'t exist', () => {
+    test('Throw error if a layer doesn\'t exist', async () => {
         const layers = ['dog']
         expect.assertions(1)
 
@@ -347,7 +355,8 @@ describe('filterLayers', () => {
   <Layer name="AIRPRT"/>
 </Map>`
 
-        return expect(filterLayers(xml, layers)).rejects.toBeInstanceOf(Error)
+        const xmlJson = await parseXml(xml)
+        return expect(filterLayers(xmlJson, layers).then(buildXml)).rejects.toBeInstanceOf(Error)
     })
 })
 


### PR DESCRIPTION
## Overview

Rather than converting the Mapnik XML to a JS object and back to XML for each step of filtering/modifying it (since there are a handful of steps) this changes to converting it at the beginning and having the filters and processing functions pass around and modify the object.  Then it converts back to XML at the end.

This also switches the base map on the demo pages to Carto Positron, since the one they were using has disappeared.

### Notes

- This is mostly copied from https://github.com/azavea/pfb-network-connectivity/commit/6701ce64ba6e380fcf95c147c29131ebaa929091
- This is primarily a simplification, though it may serve as an optimization as well.  I haven't measured, and I doubt the conversions were taking huge amounts of time, but it can't be slower and it might be faster with only the one round trip.

## Testing Instructions

Tests and demos should work the same.

Connects #129 
