### PR TITLE
Script cleanup and 'env_file' fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - "3000:3000"
       - "9229:9229"
-    env_file: .env.local
+    env_file: .env
     links:
       - database:database.internal.tilegarden
     volumes:

--- a/scripts/build-xml
+++ b/scripts/build-xml
@@ -41,7 +41,9 @@ function main() {
             mkdir -p "${out_dir}"
 
             echo "Transpiling ${file} => ${outPath}"
-            docker-compose run -e "NODE_ENV=${node_env}" -v "$PWD/${in_dir}:/home/tiler/configs" tiler ./scripts/build-xml.sh "/home/tiler/configs/${base}.mml" > ${outPath}
+            docker-compose run --rm -e "NODE_ENV=${node_env}" \
+                -v "$PWD/${in_dir}:/home/tiler/configs" \
+                tiler ./scripts/build-xml.sh "/home/tiler/configs/${base}.mml" > ${outPath}
         fi
     done
 

--- a/scripts/clean
+++ b/scripts/clean
@@ -11,7 +11,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         # Remove build artifacts from local machine
-        docker-compose run --no-deps tiler rm -rf bin/ node_modules/
+        docker-compose run --rm --no-deps tiler rm -rf bin/ node_modules/
 
         # Stop containers and shut down the network
         docker-compose down --volumes

--- a/scripts/console
+++ b/scripts/console
@@ -27,7 +27,7 @@ then
     then
         usage
     else
-        SERVER_COMMAND=${1:-start}
+        SERVER_COMMAND=${1:-tiler}
         main $SERVER_COMMAND
     fi
     exit

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -2,8 +2,8 @@
 
 set -e
 
-deploy_new=""
-no_cache=""
+DEPLOY_NEW=""
+NO_CACHE=""
 
 function usage() {
     echo -n "Usage: $(basename "${0}") [OPTION]
@@ -17,21 +17,17 @@ Options:
 }
 
 function main() {
-    if [[ $deploy_new != "--new" && ! -f ./src/tiler/claudia.json ]]; then
+    if [[ $DEPLOY_NEW != "--new" && ! -f ./src/tiler/claudia.json ]]; then
         echo "No existing deployment found to update! (did you mean to use '--new'?)"
         exit 1
     fi
 
     docker-compose build --pull terraform
 
-    if [ "${no_cache}" == "--no-cache" ]; then
-        docker-compose build --pull --no-cache tiler
-    else
-        docker-compose build --pull tiler
-    fi
+    docker-compose -f docker-compose.yml \
+                   build --pull ${NO_CACHE:+$NO_CACHE} tiler
 
-    # Capture output to check for specific error
-    ./scripts/publish "${deploy_new}"
+    ./scripts/publish ${DEPLOY_NEW:+$DEPLOY_NEW}
 }
 
 
@@ -42,11 +38,11 @@ then
     while [ $# -gt 0 ]; do
         case "$1" in
             -n| --new)
-                deploy_new='--new'
+                DEPLOY_NEW='--new'
                 shift
                 ;;
             --no-cache)
-                no_cache='--no-cache'
+                NO_CACHE='--no-cache'
                 shift
                 ;;
             -h| --help| *)

--- a/scripts/publish
+++ b/scripts/publish
@@ -2,6 +2,8 @@
 
 set -e
 
+DEPLOY_NEW=""
+
 function usage() {
     echo -n "Usage: $(basename "${0}") [OPTION]
 Publish project in development to AWS Lambda
@@ -12,12 +14,8 @@ Options:
 }
 
 function main() {
-    if [ "${1}" = "--new" ]
-    then
-        docker-compose run --rm --no-deps -e NODE_ENV=production tiler yarn deploy-new
-    else
-        docker-compose run --rm --no-deps -e NODE_ENV=production tiler yarn deploy
-    fi
+    docker-compose -f docker-compose.yml \
+                   run --rm --no-deps -e NODE_ENV=production tiler yarn deploy${DEPLOY_NEW:+-new}
 
     # Deploy CloudFront proxy
     docker-compose run terraform init
@@ -27,12 +25,14 @@ function main() {
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
-    if [ "${1:-}" = "--help" ]
-    then
-        usage
-    else
-        SERVER_COMMAND=${1:-start}
-        main $SERVER_COMMAND
-    fi
-    exit
+    case "$1" in
+        -n| --new)
+            DEPLOY_NEW='--new'
+            shift
+            ;;
+        -h| --help)
+            usage
+            exit
+    esac
+    main
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -16,7 +16,7 @@ then
     then
         usage
     else
-        docker-compose run --no-deps tiler yarn test
+        docker-compose run --rm --no-deps tiler yarn test
     fi
     exit
 fi


### PR DESCRIPTION
Some script cleanup that I did initially on the `feature/multi-environment-deployment` branch but separated off since it's not directly related and might as well go in.

Also a fix for the `env_file` name change that got into PR #138 but belongs with that other branch and broke the `develop` build.


