### PR TITLE
Move map config param from querysetring to path

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -34,3 +34,7 @@ LAMBDA_REGION=
 #LAMBDA_SUBNETS=subnet1,subnet2,subnet...N
 # VPC Security Groups that your lambdas should use (comma separated list)
 #LAMBDA_SECURITY_GROUPS=group1,group2,group...N
+
+# Set an S3 bucket to load config files from. Can be overridden with `s3bucket=`, but if this
+# is set it won't be possible to read config from the filesystem (i.e. the bundled code)
+#TILEGARDEN_CONFIG_BUCKET=

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ The AWS profile used for deployment must have at least the following policies an
 ### Features
 
 #### Configuration Selection and Storage
-Multiple map configuration `.mml` files can be included in your project's [`src/tiler/src/config`](src/tiler/src/config) to be dynamically loaded at run-time. Use the query string `config` with the name of your configuration file (without the file extension) to select which file gets loaded when rendering tiles. If no `config` is provided, Tilegarden tries to load the config file named `map-config`. 
- * _Example_: if you have a configuration file named `my-good-map.mml`, you can tell Tilegarden to use it with the endpoint `/tile/{z}/{x}/{y}.png?config=my-good-map`
+Multiple map configuration `.xml` files can be included in your project's [`src/tiler/src/config`](src/tiler/src/config) to be dynamically loaded at run-time. Use the `config` path parameter with the name of your configuration file (without the file extension) to select which file gets loaded when rendering tiles.
+
+ * _Example_: if you have a configuration file named `my-good-map.xml`, you can tell Tilegarden to use it with the endpoint `/tile/my-good-map/{z}/{x}/{y}.png`
  
- Configuration files can also be optionally loaded from an AWS S3 bucket, which allows you to add/remove/replace available maps without having to redeploy your entire project. To do so, add `&s3bucket=<bucket-name>` to your query string, and treat the `config` parameter as the desired config file's key. You can use the `build-xml` script to generate config files for this purpose without having to spin up the entire development environment, run `./scripts/build-xml --help` for more info.
+ Configuration files can also be optionally loaded from an AWS S3 bucket, which allows you to add/remove/replace available maps without having to redeploy your entire project. To do so, add `&s3bucket=<bucket-name>` to your query string, and treat the `config` parameter as the desired config file's key (omitting the `.xml` extension). You can use the `build-xml` script to generate config files for this purpose without having to spin up the entire development environment, run `./scripts/build-xml --help` for more info.
   * Accessing config files stored in S3 requires you to have deployed your Tilegarden instance using an AWS profile with read/write permissions for the desired S3 bucket. These permissions are passed on to the AWS Lambda function. **You must also manually add the `AmazonS3ReadOnlyAccess` permission to the IAM role** that gets created for your lambda, or otherwise use a custom role that has that permission, since `claudia` doesn't add it during creation.
   * `build-xml` has a `-b/--s3_bucket <name>` flag which automatically uploads built files to S3 instead of saving them to disk. This requires you to have the AWS CLI installed on your machine, and uses the AWS credentials you've specified in `.env`.
  

--- a/demo/client-filter.html
+++ b/demo/client-filter.html
@@ -38,10 +38,10 @@
 
             // add filtered layers
             function newLayer (filters) {
-                return L.tileLayer(TILESERVER_PATH + 'tile/{z}/{x}/{y}.png?config=data-type-example&layers=' + encodeURIComponent(JSON.stringify(filters)))
+                return L.tileLayer(TILESERVER_PATH + 'tile/data-type-example/{z}/{x}/{y}.png?layers=' + encodeURIComponent(JSON.stringify(filters)))
             }
 
-            var EXAMPLE_PATH = 'https://yourtiles.cloudfront.net/tile/{z}/{x}/{y}.png?layers='
+            var EXAMPLE_PATH = 'https://yourtiles.cloudfront.net/tile/CONFIG/{z}/{x}/{y}.png?layers='
 
             var INITIAL_QUERY = [
                 {
@@ -125,7 +125,7 @@
         <p class="lead">Allow users to modify pre-defined layers by specifying filter conditions.</p>
         <div class="row">
             <div class="m-auto">
-                <code id="urlExample">https://yourtiles.cloudfront.net/tile/{z}/{x}/{y}.png?layers=PARK,PRIV</code>
+                <code id="urlExample">https://yourtiles.cloudfront.net/tile/CONFIG/{z}/{x}/{y}.png?layers=PARK,PRIV</code>
             </div>
             <div class="col-8">
                 <figure class="figure">

--- a/demo/layer-filter.html
+++ b/demo/layer-filter.html
@@ -38,10 +38,10 @@
 
             // add filtered layers
             function newLayer (filters) {
-                return L.tileLayer(TILESERVER_PATH + 'tile/{z}/{x}/{y}.png?config=point-example&layers=' + filters)
+                return L.tileLayer(TILESERVER_PATH + 'tile/point-example/{z}/{x}/{y}.png?layers=' + filters)
             }
 
-            var EXAMPLE_PATH = 'https://yourtiles.cloudfront.net/tile/{z}/{x}/{y}.png?layers='
+            var EXAMPLE_PATH = 'https://yourtiles.cloudfront.net/tile/config/{z}/{x}/{y}.png?layers='
 
             // keep track of active layers so
             var currentSelection;
@@ -104,7 +104,7 @@
         <p class="lead">Define customizable map layers that can be queried by your users.</p>
         <div class="row">
             <div class="m-auto">
-                <code id="urlExample">https://yourtiles.cloudfront.net/tile/{z}/{x}/{y}.png?layers=["PARK","PRIV"]</code>
+                <code id="urlExample">https://yourtiles.cloudfront.net/tile/{config}/{z}/{x}/{y}.png?layers=["PARK","PRIV"]</code>
             </div>
             <div class="col-8">
                 <figure class="figure">

--- a/demo/raster.html
+++ b/demo/raster.html
@@ -45,7 +45,7 @@
             else TILESERVER_PATH = PROD_PATH;
 
             function makeLayer (layer) {
-                return L.tileLayer(TILESERVER_PATH + 'tile/{z}/{x}/{y}.png?config=data-type-example&layers=["' + layer + '"]');
+                return L.tileLayer(TILESERVER_PATH + 'tile/data-type-example/{z}/{x}/{y}.png?layers=["' + layer + '"]');
             }
 
             var currentLayer;

--- a/demo/utf-grid.html
+++ b/demo/utf-grid.html
@@ -38,8 +38,8 @@
             if (!host || host === 'localhost') TILESERVER_PATH = DEV_PATH;
             else TILESERVER_PATH = PROD_PATH;
 
-            L.tileLayer(TILESERVER_PATH + 'tile/{z}/{x}/{y}.png?config=data-type-example&layers=["inlets"]').addTo(map);
-            var grid = L.utfGrid(TILESERVER_PATH + 'grid/{z}/{x}/{y}?config=data-type-example&layers=["inlets"]&utfFields=owner,operator', { useJsonP: false })
+            L.tileLayer(TILESERVER_PATH + 'tile/data-type-example/{z}/{x}/{y}.png?layers=["inlets"]').addTo(map);
+            var grid = L.utfGrid(TILESERVER_PATH + 'grid/data-type-example/{z}/{x}/{y}?layers=["inlets"]&utfFields=owner,operator', { useJsonP: false })
 
             // keep track of currently active marker
             //var marker

--- a/demo/vector.html
+++ b/demo/vector.html
@@ -73,7 +73,7 @@
                     'inlets',
                     {
                         type: 'vector',
-                        tiles: [TILESERVER_PATH+'vector/{z}/{x}/{y}?config=data-type-example&layers=["inlets"]']
+                        tiles: [TILESERVER_PATH+'vector/data-type-example/{z}/{x}/{y}?layers=["inlets"]']
                     },
                 )
 
@@ -81,7 +81,7 @@
                     'street_centerline',
                     {
                         type: 'vector',
-                        tiles: [TILESERVER_PATH+'vector/{z}/{x}/{y}?config=data-type-example&layers=["street_centerline"]']
+                        tiles: [TILESERVER_PATH+'vector/data-type-example/{z}/{x}/{y}?layers=["street_centerline"]']
                     },
                 )
 
@@ -89,7 +89,7 @@
                     'pwd_parcels',
                     {
                         type: 'vector',
-                        tiles: [TILESERVER_PATH+'vector/{z}/{x}/{y}?config=data-type-example&layers=["pwd_parcels"]']
+                        tiles: [TILESERVER_PATH+'vector/data-type-example/{z}/{x}/{y}?layers=["pwd_parcels"]']
                     },
                 )
 

--- a/src/tiler/src/api.js
+++ b/src/tiler/src/api.js
@@ -67,7 +67,9 @@ const processLayers = (req) => {
 
 // Parses out the configuration specifications
 const processConfig = (req) => ({
-    s3bucket: req.queryString.s3bucket,
+    // Get the settings bucket from the querystring if it's set, else from the environment.
+    // Both can be blank, in which case the tiler will fall back to looking on the filesystem.
+    s3bucket: req.queryString.s3bucket || process.env.TILEGARDEN_CONFIG_BUCKET,
     config: req.pathParams.config,
 })
 

--- a/src/tiler/src/api.js
+++ b/src/tiler/src/api.js
@@ -68,7 +68,7 @@ const processLayers = (req) => {
 // Parses out the configuration specifications
 const processConfig = (req) => ({
     s3bucket: req.queryString.s3bucket,
-    config: req.queryString.config,
+    config: req.pathParams.config,
 })
 
 // Create new lambda API
@@ -86,7 +86,7 @@ const handleError = (e) => {
 
 // Get tile for some zxy bounds
 api.get(
-    '/tile/{z}/{x}/{y}',
+    '/tile/{config}/{z}/{x}/{y}',
     (req) => {
         try {
             const { z, x, y } = processCoords(req)
@@ -107,7 +107,7 @@ api.get(
 // Get utf grid for some zxy bounds
 // in the original implementation this alone uses cors: why?
 api.get(
-    '/grid/{z}/{x}/{y}',
+    '/grid/{config}/{z}/{x}/{y}',
     (req) => {
         try {
             const { z, x, y } = processCoords(req)
@@ -126,10 +126,10 @@ api.get(
 )
 // Catch this error because I keep doing it myself
 api.get(
-    '/utf/{z}/{x}/{y}',
+    '/utf/{config}/{z}/{x}/{y}',
     () => new APIBuilder.ApiResponse(
         /* eslint-disable-next-line quotes */
-        { message: "Invalid path, did you mean '/grid/{z}/{x}/{y}'?" },
+        { message: "Invalid path, did you mean '/grid/{config}/{z}/{x}/{y}'?" },
         { 'Content-Type': 'application/json' },
         404,
     ),
@@ -137,7 +137,7 @@ api.get(
 
 // Get a vector tile for some zxy bounds
 api.get(
-    '/vector/{z}/{x}/{y}',
+    '/vector/{config}/{z}/{x}/{y}',
     (req) => {
         try {
             const { z, x, y } = processCoords(req)
@@ -166,9 +166,9 @@ api.get(
             <body>
                 <h2>Tilegarden Usage:</h2>
                 <ul>
-                    <li>Render raster tile at zoom/x/y: <code>/tile/{z}/{x}/{y}.png</code></li>
-                    <li>Render vector tile, rather than raster: <code>/vector/{z}/{x}/{y}</code></li>
-                    <li>UTF grid at zoom/x/y: <code>/grid/{z}/{x}/{y}?utfFields=field1,field2,field...N</code></li>
+                    <li>Render raster tile at zoom/x/y: <code>/tile/{config}/{z}/{x}/{y}.png</code></li>
+                    <li>Render vector tile, rather than raster: <code>/vector/{config}/{z}/{x}/{y}</code></li>
+                    <li>UTF grid at zoom/x/y: <code>/grid/{config}/{z}/{x}/{y}?utfFields=field1,field2,field...N</code></li>
                     <li>Filter layers: add <code>?layers=layer1,layer2,layer...N</code></li>
                 </ul>
                 <a href="https://azavea.github.io/tilegarden">Check out a demo &rArr;</a>


### PR DESCRIPTION
## Overview

Moves the map config parameter out of the querystring and into the path.
Also:
- Makes it required. It's much harder to have an optional path parameter, and in any case there's not really any such thing as a "generic" map configuration, so it makes sense to require that people define one and specify it in their tile requests.
- Adds the option to set a `TILEGARDEN_CONFIG_BUCKET` environment variable and use that as the source for config files rather than having to add `s3bucket=` to the querystring.  Overriding the bucket with the querystring will still work, and if there's neither a query parameter nor an environment variable, it will still look for a file on the filesystem.
- Partly updates the relevant README section.
- Updates all the demo pages to use the new URL format

### Demo

Looks the same, but note the new piece in the URL and the lack of a `config=` param in the query.
![image](https://user-images.githubusercontent.com/6598836/64579334-885ab080-d350-11e9-9ce4-78b0b3791b3f.png)

## Testing Instructions

- Run `./scripts/server`
- The local demo pages should all work as before
- Push your config.xml files up to an S3 bucket (they have to be at the root)
- Set `TILEGARDEN_CONFIG_BUCKET` in your `.env` file and restart your dev server. Rename one of your local map config XML files and confirm that the tiles still work.
- Unset the `TILEGARDEN_CONFIG_BUCKET` variable, restart your server, and confirm the tiles stop working (because your local file is still missing).  Add `s3bucket=` with your config bucket. They should start working again.

